### PR TITLE
Add support for variable string serializers

### DIFF
--- a/.changeset/sixty-nails-reflect.md
+++ b/.changeset/sixty-nails-reflect.md
@@ -1,0 +1,22 @@
+---
+'@metaplex-foundation/umi-core': patch
+'@metaplex-foundation/umi-serializer-beet': patch
+---
+
+Add support for variable string serializers
+
+There is now three ways to serialize/deserialize a string:
+
+```ts
+// With prefix.
+umi.serializer.string().serialize('A');
+// -> 0x0100000041
+
+// Fixed.
+umi.serializer.fixedString(8).serialize('A');
+// -> 0x4100000000000000
+
+// Variable.
+umi.serializer.variableString().serialize('A');
+// -> 0x41
+```

--- a/.changeset/sixty-nails-reflect.md
+++ b/.changeset/sixty-nails-reflect.md
@@ -5,7 +5,7 @@
 
 Add support for variable string serializers
 
-There is now three ways to serialize/deserialize a string:
+There are now three ways to serialize/deserialize a string:
 
 ```ts
 // With prefix.

--- a/packages/umi-core/src/SerializerInterface.ts
+++ b/packages/umi-core/src/SerializerInterface.ts
@@ -202,7 +202,7 @@ export interface SerializerInterface {
   ) => Serializer<string>;
 
   /**
-   * Creates serializer of fixed length strings.
+   * Creates a fixed-length serializer for strings.
    *
    * @param bytes - The fixed number of bytes to read.
    * @param content - The string serializer to use for the content. Defaults to `utf8`.
@@ -210,6 +210,17 @@ export interface SerializerInterface {
    */
   fixedString: (
     bytes: number,
+    content?: Serializer<string>,
+    description?: string
+  ) => Serializer<string>;
+
+  /**
+   * Creates a variable-length serializer for strings.
+   *
+   * @param content - The string serializer to use for the content. Defaults to `utf8`.
+   * @param description - A custom description for the serializer.
+   */
+  variableString: (
     content?: Serializer<string>,
     description?: string
   ) => Serializer<string>;
@@ -334,6 +345,10 @@ export class NullSerializer implements SerializerInterface {
   }
 
   fixedString(): Serializer<string> {
+    throw this.error;
+  }
+
+  variableString(): Serializer<string> {
     throw this.error;
   }
 

--- a/packages/umi-serializer-beet/src/BeetSerializer.ts
+++ b/packages/umi-serializer-beet/src/BeetSerializer.ts
@@ -583,6 +583,18 @@ export class BeetSerializer implements SerializerInterface {
     );
   }
 
+  variableString(
+    content?: Serializer<string>,
+    description?: string
+  ): Serializer<string> {
+    const contentSerializer = content ?? utf8;
+    return {
+      ...contentSerializer,
+      description:
+        description ?? `variableString(${contentSerializer.description})`,
+    };
+  }
+
   bool(size?: NumberSerializer, description?: string): Serializer<boolean> {
     const serializer = size ?? u8();
     if (serializer.fixedSize === null) {

--- a/packages/umi-serializer-beet/test/BeetSerializer.test.ts
+++ b/packages/umi-serializer-beet/test/BeetSerializer.test.ts
@@ -316,6 +316,20 @@ test('it can serialize fixed strings', (t) => {
   t.is(doffset(fixedString(5, base58), '7893000000'), 5);
 });
 
+test('it can serialize variable strings', (t) => {
+  const { variableString } = new BeetSerializer();
+  t.is(variableString().description, 'variableString(utf8)');
+  t.is(variableString(undefined, 'My string').description, 'My string');
+  t.is(variableString().fixedSize, null);
+  t.is(variableString().maxSize, null);
+
+  // It simply delegates to the content serializer.
+  t.is(s(variableString(), 'Hello World!'), '48656c6c6f20576f726c6421');
+  t.is(d(variableString(), '48656c6c6f20576f726c6421'), 'Hello World!');
+  t.is(doffset(variableString(), '48656c6c6f20576f726c6421'), 12);
+  t.is(sd(variableString(), 'Hello World!'), 'Hello World!');
+});
+
 test('it can serialize bytes', (t) => {
   const { bytes } = new BeetSerializer();
   t.is(bytes.description, 'bytes');


### PR DESCRIPTION
There are now three ways to serialize/deserialize a string:

```ts
// With prefix.
umi.serializer.string().serialize('A');
// -> 0x0100000041

// Fixed.
umi.serializer.fixedString(8).serialize('A');
// -> 0x4100000000000000

// Variable.
umi.serializer.variableString().serialize('A');
// -> 0x41
```