### PR TITLE
Write custom transaction and message serializers

### DIFF
--- a/.changeset/shy-drinks-compete.md
+++ b/.changeset/shy-drinks-compete.md
@@ -1,0 +1,7 @@
+---
+"@metaplex-foundation/umi-transaction-factory-web3js": patch
+"@metaplex-foundation/umi-web3js-adapters": patch
+"@metaplex-foundation/umi": patch
+---
+
+Write custom transaction and message serializers

--- a/packages/umi-transaction-factory-web3js/package.json
+++ b/packages/umi-transaction-factory-web3js/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
+    "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
+    "@metaplex-foundation/umi-serializer-beet": "workspace:^",
     "@solana/web3.js": "^1.72.0",
     "ava": "^5.1.0"
   },

--- a/packages/umi-transaction-factory-web3js/src/Web3JsTransactionFactory.ts
+++ b/packages/umi-transaction-factory-web3js/src/Web3JsTransactionFactory.ts
@@ -98,30 +98,6 @@ export class Web3JsTransactionFactory implements TransactionFactoryInterface {
   getTransactionMessageSerializerForVersion(
     version: TransactionVersion
   ): Serializer<TransactionMessage> {
-    switch (version) {
-      case 'legacy':
-        return this.getTransactionMessageLegacySerializer();
-      case 0:
-      default:
-        return this.getTransactionMessageV0Serializer();
-    }
-  }
-
-  getTransactionMessageLegacySerializer(): Serializer<TransactionMessage> {
-    const s = this.context.serializer;
-    return s.struct<TransactionMessage, TransactionMessage>([
-      ['version', this.getTransactionVersionSerializer()],
-      ['header', this.getTransactionMessageHeaderSerializer()],
-      ['accounts', s.array(s.publicKey(), { size: shortU16() })],
-      ['blockhash', s.string({ encoding: base58, size: 32 })],
-      [
-        'instructions',
-        s.array(this.getCompiledInstructionSerializer(), { size: shortU16() }),
-      ],
-    ]);
-  }
-
-  getTransactionMessageV0Serializer(): Serializer<TransactionMessage> {
     const s = this.context.serializer;
     return s.struct<TransactionMessage, TransactionMessage>([
       ['version', this.getTransactionVersionSerializer()],
@@ -135,7 +111,7 @@ export class Web3JsTransactionFactory implements TransactionFactoryInterface {
       [
         'addressLookupTables',
         s.array(this.getCompiledAddressLookupTableSerializer(), {
-          size: shortU16(),
+          size: version === 'legacy' ? 0 : shortU16(),
         }),
       ],
     ]);

--- a/packages/umi-transaction-factory-web3js/src/Web3JsTransactionFactory.ts
+++ b/packages/umi-transaction-factory-web3js/src/Web3JsTransactionFactory.ts
@@ -1,33 +1,43 @@
+/* eslint-disable no-bitwise */
 import {
+  base58,
+  CompiledAddressLookupTable,
+  CompiledInstruction,
+  Context,
   SerializedTransaction,
   SerializedTransactionMessage,
+  Serializer,
   Transaction,
   TransactionFactoryInterface,
   TransactionInput,
   TransactionMessage,
+  TransactionMessageHeader,
 } from '@metaplex-foundation/umi-core';
 import {
   fromWeb3JsMessage,
   fromWeb3JsTransaction,
-  toWeb3JsMessage,
   toWeb3JsMessageFromInput,
   toWeb3JsTransaction,
 } from '@metaplex-foundation/umi-web3js-adapters';
-import {
-  VersionedTransaction as Web3JsTransaction,
-  VersionedMessage as Web3JsMessage,
-} from '@solana/web3.js';
+import { VersionedTransaction as Web3JsTransaction } from '@solana/web3.js';
 
 export class Web3JsTransactionFactory implements TransactionFactoryInterface {
+  protected readonly context: Pick<Context, 'serializer'>;
+
+  constructor(context: Web3JsTransactionFactory['context']) {
+    this.context = context;
+  }
+
   create(input: TransactionInput): Transaction {
     const web3JsMessage = toWeb3JsMessageFromInput(input);
+    const message = fromWeb3JsMessage(web3JsMessage);
     const web3JsTransaction = new Web3JsTransaction(
       web3JsMessage,
       input.signatures
     );
     return {
-      message: fromWeb3JsMessage(web3JsMessage),
-      serializedMessage: web3JsMessage.serialize(),
+      message,
+      serializedMessage: this.serializeMessage(message),
       signatures: web3JsTransaction.signatures,
     };
   }
@@ -43,12 +53,104 @@ export class Web3JsTransactionFactory implements TransactionFactoryInterface {
   }
 
   serializeMessage(message: TransactionMessage): SerializedTransactionMessage {
-    return new Uint8Array(toWeb3JsMessage(message).serialize());
+    return this.getTransactionMessageSerializer().serialize(message);
   }
 
   deserializeMessage(
     serializedMessage: SerializedTransactionMessage
   ): TransactionMessage {
-    return fromWeb3JsMessage(Web3JsMessage.deserialize(serializedMessage));
+    return this.getTransactionMessageSerializer().deserialize(
+      serializedMessage
+    )[0];
+  }
+
+  getTransactionMessageSerializer(): Serializer<TransactionMessage> {
+    const s = this.context.serializer;
+    return s.struct<TransactionMessage, TransactionMessage>([
+      // const MESSAGE_VERSION_0_PREFIX = 1 << 7;
+      ['version', s.u8()], // TODO
+      [
+        'header',
+        s.struct<TransactionMessageHeader, TransactionMessageHeader>([
+          ['numRequiredSignatures', s.u8()],
+          ['numReadonlySignedAccounts', s.u8()],
+          ['numReadonlyUnsignedAccounts', s.u8()],
+        ]),
+      ],
+      ['accounts', s.array(s.publicKey(), { size: shortU16() })],
+      ['blockhash', s.string({ encoding: base58, size: 32 })],
+      [
+        'instructions',
+        s.array(this.getCompiledInstructionSerializer(), { size: shortU16() }),
+      ],
+      [
+        'addressLookupTables',
+        s.array(this.getCompiledAddressLookupTableSerializer(), {
+          size: shortU16(),
+        }),
+      ],
+    ]);
+  }
+
+  getCompiledInstructionSerializer(): Serializer<CompiledInstruction> {
+    const s = this.context.serializer;
+    return s.struct<CompiledInstruction>([
+      ['programIndex', s.u8()],
+      ['accountIndexes', s.array(s.u8(), { size: shortU16() })],
+      ['data', s.bytes({ size: shortU16() })],
+    ]);
+  }
+
+  getCompiledAddressLookupTableSerializer(): Serializer<CompiledAddressLookupTable> {
+    const s = this.context.serializer;
+    return s.struct<CompiledAddressLookupTable>([
+      ['publicKey', s.publicKey()],
+      ['writableIndexes', s.array(s.u8(), { size: shortU16() })],
+      ['readonlyIndexes', s.array(s.u8(), { size: shortU16() })],
+    ]);
   }
 }
+
+/**
+ * Same as u16, but serialized with 1 to 3 bytes.
+ *
+ * If the value is above 0x7f, the top bit is set and the remaining
+ * value is stored in the next bytes. Each byte follows the same
+ * pattern until the 3rd byte. The 3rd byte, if needed, uses
+ * all 8 bits to store the last byte of the original value.
+ */
+export const shortU16 = (): Serializer<number> => ({
+  description: 'shortU16',
+  fixedSize: null,
+  maxSize: 3,
+  serialize: (value: number): Uint8Array => {
+    const bytes = [] as number[];
+    let remainingValue = value;
+    for (;;) {
+      let elem = remainingValue & 0x7f;
+      remainingValue >>= 7;
+      if (remainingValue === 0) {
+        bytes.push(elem);
+        break;
+      } else {
+        elem |= 0x80;
+        bytes.push(elem);
+      }
+    }
+    return new Uint8Array(bytes);
+  },
+  deserialize: (buffer: Uint8Array, offset = 0): [number, number] => {
+    const bytes = [...buffer.slice(offset)];
+    let len = 0;
+    let size = 0;
+    for (;;) {
+      const elem = bytes.shift() as number;
+      len |= (elem & 0x7f) << (size * 7);
+      size += 1;
+      if ((elem & 0x80) === 0) {
+        break;
+      }
+    }
+    return [len, offset + size];
+  },
+});

--- a/packages/umi-transaction-factory-web3js/src/plugin.ts
+++ b/packages/umi-transaction-factory-web3js/src/plugin.ts
@@ -3,6 +3,6 @@ import { Web3JsTransactionFactory } from './Web3JsTransactionFactory';
 
 export const web3JsTransactionFactory = (): UmiPlugin => ({
   install(umi) {
-    umi.transactions = new Web3JsTransactionFactory();
+    umi.transactions = new Web3JsTransactionFactory(umi);
   },
 });

--- a/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
+++ b/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
@@ -1,6 +1,21 @@
 import test from 'ava';
-import { web3JsTransactionFactory } from '../src';
+import { createLegacyMessage, createUmi } from './_setup';
 
-test('example test', async (t) => {
-  t.is(typeof web3JsTransactionFactory, 'function');
+test('it can serialize a legacy message', async (t) => {
+  const umi = createUmi();
+  const [legacyMessage, web3JsLegacyMessage] = createLegacyMessage(umi);
+  const serialized = umi.transactions.serializeMessage(legacyMessage);
+  t.deepEqual(serialized, new Uint8Array(web3JsLegacyMessage.serialize()));
 });
+
+test('it can deserialize a legacy message', async (t) => {
+  const umi = createUmi();
+  const [originalMessage, web3JsLegacyMessage] = createLegacyMessage(umi);
+  const serializedMessage = new Uint8Array(web3JsLegacyMessage.serialize());
+  const deserializedMessage =
+    umi.transactions.deserializeMessage(serializedMessage);
+  t.deepEqual(deserializedMessage, originalMessage);
+});
+
+// it can serialize a v0 message
+// it can deserialize a v0 message

--- a/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
+++ b/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
@@ -1,27 +1,11 @@
 import test from 'ava';
 import {
   createLegacyMessage,
+  createOversizedTransaction,
   createUmi,
   createV0Message,
   createV0Transaction,
 } from './_setup';
-
-test('it can serialize a transaction', async (t) => {
-  const umi = createUmi();
-  const [transaction, web3JsTransaction] = createV0Transaction(umi);
-  const serialized = umi.transactions.serialize(transaction);
-  t.deepEqual(serialized, web3JsTransaction.serialize());
-});
-
-test('it can deserialize a transaction', async (t) => {
-  const umi = createUmi();
-  const [originalTransaction, web3JsTransaction] = createV0Transaction(umi);
-  const serializedTransaction = web3JsTransaction.serialize();
-  const deserializedTransaction = umi.transactions.deserialize(
-    serializedTransaction
-  );
-  t.deepEqual(deserializedTransaction, originalTransaction);
-});
 
 test('it can serialize a legacy message', async (t) => {
   const umi = createUmi();
@@ -53,4 +37,28 @@ test('it can deserialize a V0 message', async (t) => {
   const deserializedMessage =
     umi.transactions.deserializeMessage(serializedMessage);
   t.deepEqual(deserializedMessage, originalMessage);
+});
+
+test('it can serialize a transaction', async (t) => {
+  const umi = createUmi();
+  const [transaction, web3JsTransaction] = createV0Transaction(umi);
+  const serialized = umi.transactions.serialize(transaction);
+  t.deepEqual(serialized, web3JsTransaction.serialize());
+});
+
+test('it can deserialize a transaction', async (t) => {
+  const umi = createUmi();
+  const [originalTransaction, web3JsTransaction] = createV0Transaction(umi);
+  const serializedTransaction = web3JsTransaction.serialize();
+  const deserializedTransaction = umi.transactions.deserialize(
+    serializedTransaction
+  );
+  t.deepEqual(deserializedTransaction, originalTransaction);
+});
+
+test('it can serialize an oversized transaction', async (t) => {
+  const umi = createUmi();
+  const [transaction] = createOversizedTransaction(umi);
+  const transactionSize = umi.transactions.serialize(transaction).length;
+  t.is(transactionSize, 14669);
 });

--- a/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
+++ b/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { createLegacyMessage, createUmi } from './_setup';
+import { createLegacyMessage, createUmi, createV0Message } from './_setup';
 
 test('it can serialize a legacy message', async (t) => {
   const umi = createUmi();
@@ -17,5 +17,18 @@ test('it can deserialize a legacy message', async (t) => {
   t.deepEqual(deserializedMessage, originalMessage);
 });
 
-// it can serialize a v0 message
-// it can deserialize a v0 message
+test('it can serialize a V0 message', async (t) => {
+  const umi = createUmi();
+  const [v0Message, web3JsV0Message] = createV0Message(umi);
+  const serialized = umi.transactions.serializeMessage(v0Message);
+  t.deepEqual(serialized, new Uint8Array(web3JsV0Message.serialize()));
+});
+
+test('it can deserialize a V0 message', async (t) => {
+  const umi = createUmi();
+  const [originalMessage, web3JsV0Message] = createV0Message(umi);
+  const serializedMessage = new Uint8Array(web3JsV0Message.serialize());
+  const deserializedMessage =
+    umi.transactions.deserializeMessage(serializedMessage);
+  t.deepEqual(deserializedMessage, originalMessage);
+});

--- a/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
+++ b/packages/umi-transaction-factory-web3js/test/Web3JsTransactionFactory.test.ts
@@ -1,5 +1,27 @@
 import test from 'ava';
-import { createLegacyMessage, createUmi, createV0Message } from './_setup';
+import {
+  createLegacyMessage,
+  createUmi,
+  createV0Message,
+  createV0Transaction,
+} from './_setup';
+
+test('it can serialize a transaction', async (t) => {
+  const umi = createUmi();
+  const [transaction, web3JsTransaction] = createV0Transaction(umi);
+  const serialized = umi.transactions.serialize(transaction);
+  t.deepEqual(serialized, web3JsTransaction.serialize());
+});
+
+test('it can deserialize a transaction', async (t) => {
+  const umi = createUmi();
+  const [originalTransaction, web3JsTransaction] = createV0Transaction(umi);
+  const serializedTransaction = web3JsTransaction.serialize();
+  const deserializedTransaction = umi.transactions.deserialize(
+    serializedTransaction
+  );
+  t.deepEqual(deserializedTransaction, originalTransaction);
+});
 
 test('it can serialize a legacy message', async (t) => {
   const umi = createUmi();
@@ -21,13 +43,13 @@ test('it can serialize a V0 message', async (t) => {
   const umi = createUmi();
   const [v0Message, web3JsV0Message] = createV0Message(umi);
   const serialized = umi.transactions.serializeMessage(v0Message);
-  t.deepEqual(serialized, new Uint8Array(web3JsV0Message.serialize()));
+  t.deepEqual(serialized, web3JsV0Message.serialize());
 });
 
 test('it can deserialize a V0 message', async (t) => {
   const umi = createUmi();
   const [originalMessage, web3JsV0Message] = createV0Message(umi);
-  const serializedMessage = new Uint8Array(web3JsV0Message.serialize());
+  const serializedMessage = web3JsV0Message.serialize();
   const deserializedMessage =
     umi.transactions.deserializeMessage(serializedMessage);
   t.deepEqual(deserializedMessage, originalMessage);

--- a/packages/umi-transaction-factory-web3js/test/_setup.ts
+++ b/packages/umi-transaction-factory-web3js/test/_setup.ts
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import {
+  createUmi as baseCreateUmi,
+  generateSigner,
+  TransactionMessage,
+  Umi,
+} from '@metaplex-foundation/umi-core';
+import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
+import { beetSerializer } from '@metaplex-foundation/umi-serializer-beet';
+import {
+  fromWeb3JsMessage,
+  toWeb3JsPublicKey,
+} from '@metaplex-foundation/umi-web3js-adapters';
+import {
+  AddressLookupTableAccount as Web3JsAddressLookupTableAccount,
+  Message as Web3JsLegacyMessage,
+  MessageV0 as Web3JsV0Message,
+  SystemProgram,
+} from '@solana/web3.js';
+import { web3JsTransactionFactory } from '../src';
+
+export const createUmi = (): Umi =>
+  baseCreateUmi()
+    .use(beetSerializer())
+    .use(web3JsEddsa())
+    .use(web3JsTransactionFactory());
+
+export const createLegacyMessage = (
+  umi: Umi
+): [TransactionMessage, Web3JsLegacyMessage] => {
+  const fromPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+  const toPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+  const web3JsLegacyMessage = Web3JsLegacyMessage.compile({
+    payerKey: toWeb3JsPublicKey(generateSigner(umi).publicKey),
+    instructions: [
+      SystemProgram.transfer({ fromPubkey, toPubkey, lamports: 1_000_000_000 }),
+    ],
+    recentBlockhash: '11111111111111111111111111111111',
+  });
+  return [fromWeb3JsMessage(web3JsLegacyMessage), web3JsLegacyMessage];
+};
+
+export const createV0Message = (
+  umi: Umi
+): [TransactionMessage, Web3JsV0Message] => {
+  const fromPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+  const toPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+  const web3JsV0Message = Web3JsV0Message.compile({
+    payerKey: toWeb3JsPublicKey(generateSigner(umi).publicKey),
+    instructions: [
+      SystemProgram.transfer({ fromPubkey, toPubkey, lamports: 1_000_000_000 }),
+    ],
+    recentBlockhash: '11111111111111111111111111111111',
+    addressLookupTableAccounts: [
+      new Web3JsAddressLookupTableAccount({
+        key: toWeb3JsPublicKey(generateSigner(umi).publicKey),
+        state: {
+          deactivationSlot: BigInt(`0x${'ff'.repeat(8)}`),
+          lastExtendedSlot: 0,
+          lastExtendedSlotStartIndex: 0,
+          addresses: [
+            toPubkey,
+            toWeb3JsPublicKey(generateSigner(umi).publicKey),
+          ],
+        },
+      }),
+    ],
+  });
+  return [fromWeb3JsMessage(web3JsV0Message), web3JsV0Message];
+};

--- a/packages/umi-transaction-factory-web3js/test/_setup.ts
+++ b/packages/umi-transaction-factory-web3js/test/_setup.ts
@@ -2,6 +2,8 @@
 import {
   createUmi as baseCreateUmi,
   generateSigner,
+  KeypairSigner,
+  Transaction,
   TransactionMessage,
   Umi,
 } from '@metaplex-foundation/umi-core';
@@ -9,6 +11,8 @@ import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
 import { beetSerializer } from '@metaplex-foundation/umi-serializer-beet';
 import {
   fromWeb3JsMessage,
+  fromWeb3JsTransaction,
+  toWeb3JsKeypair,
   toWeb3JsPublicKey,
 } from '@metaplex-foundation/umi-web3js-adapters';
 import {
@@ -16,6 +20,7 @@ import {
   Message as Web3JsLegacyMessage,
   MessageV0 as Web3JsV0Message,
   SystemProgram,
+  VersionedTransaction as Web3JsTransaction,
 } from '@solana/web3.js';
 import { web3JsTransactionFactory } from '../src';
 
@@ -27,8 +32,9 @@ export const createUmi = (): Umi =>
 
 export const createLegacyMessage = (
   umi: Umi
-): [TransactionMessage, Web3JsLegacyMessage] => {
-  const fromPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+): [TransactionMessage, Web3JsLegacyMessage, KeypairSigner[]] => {
+  const fromPubkeySigner = generateSigner(umi);
+  const fromPubkey = toWeb3JsPublicKey(fromPubkeySigner.publicKey);
   const toPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
   const web3JsLegacyMessage = Web3JsLegacyMessage.compile({
     payerKey: toWeb3JsPublicKey(generateSigner(umi).publicKey),
@@ -37,13 +43,18 @@ export const createLegacyMessage = (
     ],
     recentBlockhash: '11111111111111111111111111111111',
   });
-  return [fromWeb3JsMessage(web3JsLegacyMessage), web3JsLegacyMessage];
+  return [
+    fromWeb3JsMessage(web3JsLegacyMessage),
+    web3JsLegacyMessage,
+    [fromPubkeySigner],
+  ];
 };
 
 export const createV0Message = (
   umi: Umi
-): [TransactionMessage, Web3JsV0Message] => {
-  const fromPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
+): [TransactionMessage, Web3JsV0Message, KeypairSigner[]] => {
+  const fromPubkeySigner = generateSigner(umi);
+  const fromPubkey = toWeb3JsPublicKey(fromPubkeySigner.publicKey);
   const toPubkey = toWeb3JsPublicKey(generateSigner(umi).publicKey);
   const web3JsV0Message = Web3JsV0Message.compile({
     payerKey: toWeb3JsPublicKey(generateSigner(umi).publicKey),
@@ -66,5 +77,18 @@ export const createV0Message = (
       }),
     ],
   });
-  return [fromWeb3JsMessage(web3JsV0Message), web3JsV0Message];
+  return [
+    fromWeb3JsMessage(web3JsV0Message),
+    web3JsV0Message,
+    [fromPubkeySigner],
+  ];
+};
+
+export const createV0Transaction = (
+  umi: Umi
+): [Transaction, Web3JsTransaction] => {
+  const [, web3JsV0Message, signers] = createV0Message(umi);
+  const web3JsTransaction = new Web3JsTransaction(web3JsV0Message);
+  web3JsTransaction.sign(signers.map(toWeb3JsKeypair));
+  return [fromWeb3JsTransaction(web3JsTransaction), web3JsTransaction];
 };

--- a/packages/umi-web3js-adapters/src/TransactionMessage.ts
+++ b/packages/umi-web3js-adapters/src/TransactionMessage.ts
@@ -22,7 +22,7 @@ export function fromWeb3JsMessage(
     instructions: message.compiledInstructions.map((instruction) => ({
       programIndex: instruction.programIdIndex,
       accountIndexes: instruction.accountKeyIndexes,
-      data: instruction.data,
+      data: new Uint8Array(instruction.data),
     })),
     addressLookupTables: message.addressTableLookups.map((lookup) => ({
       publicKey: fromWeb3JsPublicKey(lookup.accountKey),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,6 +274,8 @@ importers:
     specifiers:
       '@ava/typescript': ^3.0.1
       '@metaplex-foundation/umi-core': workspace:^
+      '@metaplex-foundation/umi-eddsa-web3js': workspace:^
+      '@metaplex-foundation/umi-serializer-beet': workspace:^
       '@metaplex-foundation/umi-web3js-adapters': workspace:^
       '@solana/web3.js': ^1.72.0
       ava: ^5.1.0
@@ -282,6 +284,8 @@ importers:
       '@metaplex-foundation/umi-web3js-adapters': link:../umi-web3js-adapters
     devDependencies:
       '@ava/typescript': 3.0.1
+      '@metaplex-foundation/umi-eddsa-web3js': link:../umi-eddsa-web3js
+      '@metaplex-foundation/umi-serializer-beet': link:../umi-serializer-beet
       '@solana/web3.js': 1.72.0
       ava: 5.1.0_@ava+typescript@3.0.1
 


### PR DESCRIPTION
Because the once provided by Web3.js fail if they exceed the tx limit which makes it difficult to build size helpers on top of that.