### PR TITLE
fix(dataview-serializer): assert array buffer length when converting from uint8array

### DIFF
--- a/.changeset/honest-buckets-beam.md
+++ b/.changeset/honest-buckets-beam.md
@@ -1,6 +1,5 @@
 ---
 "@metaplex-foundation/umi-serializer-data-view": patch
-"@metaplex-foundation/umi": patch
 ---
 
 fix(dataview-serializer): assert array buffer length when converting from uint8array

--- a/.changeset/honest-buckets-beam.md
+++ b/.changeset/honest-buckets-beam.md
@@ -1,0 +1,6 @@
+---
+"@metaplex-foundation/umi-serializer-data-view": patch
+"@metaplex-foundation/umi": patch
+---
+
+fix(dataview-serializer): assert array buffer length when converting from uint8array

--- a/packages/umi-serializer-data-view/src/helpers.ts
+++ b/packages/umi-serializer-data-view/src/helpers.ts
@@ -1,0 +1,10 @@
+/**
+ * Helper function to ensure that the array buffer is converted properly from a uint8array
+ * Source: https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
+ * @param {Uint8Array} array Uint8array that's being converted into an array buffer
+ * @returns {ArrayBuffer} An array buffer that's necessary to construct a data view
+ */
+export function UInt8ArrayToBuffer(array: Uint8Array): ArrayBuffer {
+    return array.buffer.slice(array.byteOffset, array.byteLength + array.byteOffset)
+
+}

--- a/packages/umi-serializer-data-view/src/helpers.ts
+++ b/packages/umi-serializer-data-view/src/helpers.ts
@@ -5,6 +5,8 @@
  * @returns {ArrayBuffer} An array buffer that's necessary to construct a data view
  */
 export function UInt8ArrayToBuffer(array: Uint8Array): ArrayBuffer {
-    return array.buffer.slice(array.byteOffset, array.byteLength + array.byteOffset)
-
+  return array.buffer.slice(
+    array.byteOffset,
+    array.byteLength + array.byteOffset
+  );
 }

--- a/packages/umi-serializer-data-view/src/numbers.ts
+++ b/packages/umi-serializer-data-view/src/numbers.ts
@@ -50,7 +50,9 @@ export const u8 = (
   },
   deserialize(bytes, offset = 0): [number, number] {
     assertEnoughBytes('u8', bytes.slice(offset), 1);
-    const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 1)));
+    const view = new DataView(
+      UInt8ArrayToBuffer(bytes.slice(offset, offset + 1))
+    );
     return [view.getUint8(0), offset + 1];
   },
 });
@@ -70,7 +72,9 @@ export const i8 = (
   },
   deserialize(bytes, offset = 0): [number, number] {
     assertEnoughBytes('i8', bytes.slice(offset), 1);
-    const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 1)));
+    const view = new DataView(
+      UInt8ArrayToBuffer(bytes.slice(offset, offset + 1))
+    );
     return [view.getInt8(0), offset + 1];
   },
 });
@@ -92,7 +96,9 @@ export const u16 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('u16', bytes.slice(offset), 2);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 2)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 2))
+      );
       return [view.getUint16(0, littleEndian), offset + 2];
     },
   };
@@ -116,7 +122,9 @@ export const i16 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('i16', bytes.slice(offset), 2);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 2)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 2))
+      );
       return [view.getInt16(0, littleEndian), offset + 2];
     },
   };
@@ -139,7 +147,9 @@ export const u32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('u32', bytes.slice(offset), 4);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 4))
+      );
       return [view.getUint32(0, littleEndian), offset + 4];
     },
   };
@@ -163,7 +173,9 @@ export const i32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('i32', bytes.slice(offset), 4);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 4))
+      );
       return [view.getInt32(0, littleEndian), offset + 4];
     },
   };
@@ -187,7 +199,9 @@ export const u64 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('u64', bytes.slice(offset), 8);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 8))
+      );
       return [view.getBigUint64(0, littleEndian), offset + 8];
     },
   };
@@ -212,7 +226,9 @@ export const i64 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('i64', bytes.slice(offset), 8);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 8))
+      );
       return [view.getBigInt64(0, littleEndian), offset + 8];
     },
   };
@@ -242,7 +258,9 @@ export const u128 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('u128', bytes.slice(offset), 16);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 16)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 16))
+      );
       const leftOffset = littleEndian ? 8 : 0;
       const rightOffset = littleEndian ? 0 : 8;
       const left = view.getBigUint64(leftOffset, littleEndian);
@@ -276,7 +294,9 @@ export const i128 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('i128', bytes.slice(offset), 16);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 16)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 16))
+      );
       const leftOffset = littleEndian ? 8 : 0;
       const rightOffset = littleEndian ? 0 : 8;
       const left = view.getBigInt64(leftOffset, littleEndian);
@@ -302,7 +322,9 @@ export const f32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('f32', bytes.slice(offset), 4);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 4))
+      );
       return [view.getFloat32(0, littleEndian), offset + 4];
     },
   };
@@ -324,7 +346,9 @@ export const f64 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('f64', bytes.slice(offset), 8);
-      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
+      const view = new DataView(
+        UInt8ArrayToBuffer(bytes.slice(offset, offset + 8))
+      );
       return [view.getFloat64(0, littleEndian), offset + 8];
     },
   };

--- a/packages/umi-serializer-data-view/src/numbers.ts
+++ b/packages/umi-serializer-data-view/src/numbers.ts
@@ -10,6 +10,7 @@ import {
   NotEnoughBytesError,
   NumberOutOfRangeError,
 } from './errors';
+import { UInt8ArrayToBuffer } from './helpers';
 
 const assertRange = (
   serializer: string,
@@ -49,7 +50,7 @@ export const u8 = (
   },
   deserialize(bytes, offset = 0): [number, number] {
     assertEnoughBytes('u8', bytes.slice(offset), 1);
-    const view = new DataView(bytes.slice(offset, offset + 1).buffer);
+    const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 1)));
     return [view.getUint8(0), offset + 1];
   },
 });
@@ -69,7 +70,7 @@ export const i8 = (
   },
   deserialize(bytes, offset = 0): [number, number] {
     assertEnoughBytes('i8', bytes.slice(offset), 1);
-    const view = new DataView(bytes.slice(offset, offset + 1).buffer);
+    const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 1)));
     return [view.getInt8(0), offset + 1];
   },
 });
@@ -91,7 +92,7 @@ export const u16 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('u16', bytes.slice(offset), 2);
-      const view = new DataView(bytes.slice(offset, offset + 2).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 2)));
       return [view.getUint16(0, littleEndian), offset + 2];
     },
   };
@@ -115,7 +116,7 @@ export const i16 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('i16', bytes.slice(offset), 2);
-      const view = new DataView(bytes.slice(offset, offset + 2).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 2)));
       return [view.getInt16(0, littleEndian), offset + 2];
     },
   };
@@ -138,7 +139,7 @@ export const u32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('u32', bytes.slice(offset), 4);
-      const view = new DataView(bytes.slice(offset, offset + 4).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
       return [view.getUint32(0, littleEndian), offset + 4];
     },
   };
@@ -162,7 +163,7 @@ export const i32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('i32', bytes.slice(offset), 4);
-      const view = new DataView(bytes.slice(offset, offset + 4).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
       return [view.getInt32(0, littleEndian), offset + 4];
     },
   };
@@ -186,7 +187,7 @@ export const u64 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('u64', bytes.slice(offset), 8);
-      const view = new DataView(bytes.slice(offset, offset + 8).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
       return [view.getBigUint64(0, littleEndian), offset + 8];
     },
   };
@@ -211,7 +212,7 @@ export const i64 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('i64', bytes.slice(offset), 8);
-      const view = new DataView(bytes.slice(offset, offset + 8).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
       return [view.getBigInt64(0, littleEndian), offset + 8];
     },
   };
@@ -241,7 +242,7 @@ export const u128 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('u128', bytes.slice(offset), 16);
-      const view = new DataView(bytes.slice(offset, offset + 16).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 16)));
       const leftOffset = littleEndian ? 8 : 0;
       const rightOffset = littleEndian ? 0 : 8;
       const left = view.getBigUint64(leftOffset, littleEndian);
@@ -275,7 +276,7 @@ export const i128 = (
     },
     deserialize(bytes, offset = 0): [bigint, number] {
       assertEnoughBytes('i128', bytes.slice(offset), 16);
-      const view = new DataView(bytes.slice(offset, offset + 16).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 16)));
       const leftOffset = littleEndian ? 8 : 0;
       const rightOffset = littleEndian ? 0 : 8;
       const left = view.getBigInt64(leftOffset, littleEndian);
@@ -301,7 +302,7 @@ export const f32 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('f32', bytes.slice(offset), 4);
-      const view = new DataView(bytes.slice(offset, offset + 4).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 4)));
       return [view.getFloat32(0, littleEndian), offset + 4];
     },
   };
@@ -323,7 +324,7 @@ export const f64 = (
     },
     deserialize(bytes, offset = 0): [number, number] {
       assertEnoughBytes('f64', bytes.slice(offset), 8);
-      const view = new DataView(bytes.slice(offset, offset + 8).buffer);
+      const view = new DataView(UInt8ArrayToBuffer(bytes.slice(offset, offset + 8)));
       return [view.getFloat64(0, littleEndian), offset + 8];
     },
   };


### PR DESCRIPTION
Faced some problems when trying to use dataview-serializer to deserialize number types from a buffer. 

Using sysvar clock as an example with a struct layout of

```
{
  name: "Clock",
  type: {
    kind: "struct",
    fields: [
        {
          name: "slot",
          type: "u64",
        },
        {
          name: "epoch_start_timestamp",
          type: "i64",
        },
        {
          name: "epoch",
          type: "u64",
        },
        {
          name: "leader_schedule_epoch",
          type: "u64",
        },
        {
          name: "unix_timestamp",
          type: "i64",
        },
      ],
    },
}
```
The deserialized data was deserialized to this

```
[{
  "clock": {
  "slot": "8247343400600433954",
  "epochStartTimestamp": "8247343400600433954",
  "epoch": "8247343400600433954",
  "leaderScheduleEpoch": "8247343400600433954",
  "unixTimestamp": "8247343400600433954"
}
}, 40]
```
    
which is clearly wrong because the data should be 
```
"info": {
  "epoch": 443,
  "epochStartTimestamp": 1682877087,
  "leaderScheduleEpoch": 444,
  "slot": 191683902,
  "unixTimestamp": 1683019457
}
```

Upon looking further into this issue, I found out that the arraybuffer that was converted is pretty weird and doesnt corresponds to whatever the bytes were sliced. 

```
bytesSliced <Buffer 22 eb 6c 0b 00 00 00 00>
sliced ArrayBuffer {
  [Uint8Contents]: <22 75 73 65 20 73 74 72 69 63 74 22 3b 0a 4f 62 6a 65 63 74 2e 64 65 66 69 6e 65 50 72 6f 70 65 72 74 79 28 65 78 70 6f 72 74 73 2c 20 22 5f 5f 65 73 4d 6f 64 75 6c 65 22 2c 20 7b 20 76 61 6c 75 65 3a 20 74 72 75 65 20 7d 29 3b 0a 65 78 70 6f 72 74 73 2e 6f 75 74 70 75 74 20 3d 20 65 78 70 6f 72 74 ... 8092 more bytes>,
  byteLength: 8192
}
```

Hence I have implemented a solution from https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer to assert the size of the arraybuffer when converting from the sliced UInt8Array bytes. 

Not so sure if that's the correct way of doing it so let me know if you have any problems