### PR TITLE
Add support for program bindings and cloning

### DIFF
--- a/.changeset/early-lamps-complain.md
+++ b/.changeset/early-lamps-complain.md
@@ -1,0 +1,6 @@
+---
+'@metaplex-foundation/umi-program-repository': patch
+'@metaplex-foundation/umi': patch
+---
+
+Add support for cloning a program repository

--- a/.changeset/great-rocks-watch.md
+++ b/.changeset/great-rocks-watch.md
@@ -1,0 +1,6 @@
+---
+'@metaplex-foundation/umi-program-repository': patch
+'@metaplex-foundation/umi': patch
+---
+
+Add program bindings

--- a/packages/umi-program-repository/src/createDefaultProgramRepository.ts
+++ b/packages/umi-program-repository/src/createDefaultProgramRepository.ts
@@ -90,7 +90,8 @@ export function createDefaultProgramRepository(
     delete bindings[abstract];
   };
 
-  const clone = (): ProgramRepositoryInterface => createDefaultProgramRepository(context, programs, bindings);
+  const clone = (): ProgramRepositoryInterface =>
+    createDefaultProgramRepository(context, programs, bindings);
 
   const resolveError = (
     error: ErrorWithLogs,

--- a/packages/umi-program-repository/src/createDefaultProgramRepository.ts
+++ b/packages/umi-program-repository/src/createDefaultProgramRepository.ts
@@ -90,9 +90,7 @@ export function createDefaultProgramRepository(
     delete bindings[abstract];
   };
 
-  const clone = (): ProgramRepositoryInterface => {
-    return createDefaultProgramRepository(context, programs, bindings);
-  };
+  const clone = (): ProgramRepositoryInterface => createDefaultProgramRepository(context, programs, bindings);
 
   const resolveError = (
     error: ErrorWithLogs,

--- a/packages/umi-program-repository/test/_setup.ts
+++ b/packages/umi-program-repository/test/_setup.ts
@@ -1,0 +1,26 @@
+import {
+  Cluster,
+  PublicKeyInput,
+  RpcInterface,
+  createUmi as baseCreateUmi,
+  defaultPublicKey,
+  publicKey,
+} from '@metaplex-foundation/umi';
+import { defaultProgramRepository } from '../src';
+
+export const createUmi = (cluster: Cluster = 'localnet') => {
+  const umi = baseCreateUmi().use(defaultProgramRepository());
+  umi.rpc = { getCluster: () => cluster } as RpcInterface;
+  return umi;
+};
+
+export const createProgram = (
+  name: string,
+  publicKeyInput: PublicKeyInput = defaultPublicKey()
+) => ({
+  name,
+  publicKey: publicKey(publicKeyInput),
+  getErrorFromCode: () => null,
+  getErrorFromName: () => null,
+  isOnCluster: () => true,
+});

--- a/packages/umi-program-repository/test/add.test.ts
+++ b/packages/umi-program-repository/test/add.test.ts
@@ -1,0 +1,72 @@
+import { Program, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import { createUmi } from './_setup';
+
+test('it can add programs', async (t) => {
+  // Given a Program.
+  const umi = createUmi();
+  const programId = publicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+  const program: Program = {
+    name: 'myProgram',
+    publicKey: programId,
+    getErrorFromCode: () => null,
+    getErrorFromName: () => null,
+    isOnCluster: () => true,
+  };
+
+  // When we add it to the default program repository.
+  umi.programs.add(program);
+
+  // Then we can assert that it was added.
+  t.true(umi.programs.has('myProgram'));
+  t.true(umi.programs.has(programId));
+
+  // And we can retrieve it.
+  t.is(umi.programs.get('myProgram'), program);
+  t.is(umi.programs.get(programId), program);
+
+  // And it is part of the returned array of programs.
+  t.deepEqual(umi.programs.all(), [program]);
+});
+
+test('it can add programs to specific clusters', async (t) => {
+  // Given our Umi instance is on the devnet cluster.
+  const umi = createUmi('devnet');
+
+  // And given two variants of a Program, one for mainnet and one for devnet.
+  const programId = publicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+  const devnetProgram: Program = {
+    name: 'myProgram',
+    publicKey: programId,
+    getErrorFromCode: () => null,
+    getErrorFromName: () => null,
+    isOnCluster: (cluster) => cluster === 'devnet',
+  };
+  const mainnetProgram: Program = {
+    name: 'myProgram',
+    publicKey: programId,
+    getErrorFromCode: () => null,
+    getErrorFromName: () => null,
+    isOnCluster: (cluster) => cluster === 'mainnet-beta',
+  };
+
+  // When we add them to the default program repository.
+  umi.programs.add(devnetProgram);
+  umi.programs.add(mainnetProgram);
+
+  // Then we get the devnet program by default.
+  t.is(umi.programs.get('myProgram'), devnetProgram);
+  t.is(umi.programs.get(programId), devnetProgram);
+
+  // But we can also request the mainnet program explicitly.
+  t.is(umi.programs.get('myProgram', 'mainnet-beta'), mainnetProgram);
+  t.is(umi.programs.get(programId, 'mainnet-beta'), mainnetProgram);
+
+  // And only the devnet program is part of the returned array of programs by default.
+  t.deepEqual(umi.programs.all(), [devnetProgram]);
+
+  // But both of them are part of the returned array of programs when we request all clusters.
+  t.is(umi.programs.all('*').length, 2);
+  t.true(umi.programs.all('*').includes(devnetProgram));
+  t.true(umi.programs.all('*').includes(mainnetProgram));
+});

--- a/packages/umi-program-repository/test/add.test.ts
+++ b/packages/umi-program-repository/test/add.test.ts
@@ -1,6 +1,6 @@
 import { Program, publicKey } from '@metaplex-foundation/umi';
 import test from 'ava';
-import { createUmi } from './_setup';
+import { createProgram, createUmi } from './_setup';
 
 test('it can add programs', async (t) => {
   // Given a Program.
@@ -69,4 +69,18 @@ test('it can add programs to specific clusters', async (t) => {
   t.is(umi.programs.all('*').length, 2);
   t.true(umi.programs.all('*').includes(devnetProgram));
   t.true(umi.programs.all('*').includes(mainnetProgram));
+});
+
+test('it can ignore adding programs when they are already registered', async (t) => {
+  // Given a registered program.
+  const umi = createUmi();
+  const program = createProgram('myProgram');
+  umi.programs.add(program);
+
+  // When we add it again with the `overwrite` flag set to `false`.
+  umi.programs.add(program, false);
+
+  // Then it is not added again.
+  t.is(umi.programs.all().length, 1);
+  t.deepEqual(umi.programs.all(), [program]);
 });

--- a/packages/umi-program-repository/test/bindings.test.ts
+++ b/packages/umi-program-repository/test/bindings.test.ts
@@ -1,0 +1,93 @@
+import { Program, publicKey } from '@metaplex-foundation/umi';
+import test from 'ava';
+import { createProgram, createUmi } from './_setup';
+
+test('it can bind a name to another name', async (t) => {
+  // Given two registered programs: splToken and splToken2022.
+  const umi = createUmi();
+  const splTokenProgram: Program = createProgram(
+    'splToken',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  );
+  const splToken2022Program: Program = createProgram(
+    'splToken2022',
+    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+  );
+  umi.programs.add(splTokenProgram);
+  umi.programs.add(splToken2022Program);
+  t.is(umi.programs.get('splToken'), splTokenProgram);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+
+  // When we add a binding that uses splToken2022 when requesting splToken.
+  umi.programs.bind('splToken', 'splToken2022');
+
+  // Then both program names will resolve to the splToken2022 program.
+  t.is(umi.programs.get('splToken'), splToken2022Program);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+});
+
+test('it can bind a name to another public key', async (t) => {
+  // Given two registered programs: splToken and splToken2022.
+  const umi = createUmi();
+  const splTokenProgram: Program = createProgram(
+    'splToken',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  );
+  const splToken2022Program: Program = createProgram(
+    'splToken2022',
+    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+  );
+  umi.programs.add(splTokenProgram);
+  umi.programs.add(splToken2022Program);
+  t.is(umi.programs.get('splToken'), splTokenProgram);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+
+  // When we add a binding that uses the public key of splToken2022 when requesting splToken.
+  umi.programs.bind('splToken', splToken2022Program.publicKey);
+
+  // Then both program names will resolve to the splToken2022 program.
+  t.is(umi.programs.get('splToken'), splToken2022Program);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+});
+
+test('the resolved binding has to be a registered program', async (t) => {
+  // Given only the splToken program is registered.
+  const umi = createUmi();
+  const splTokenProgram: Program = createProgram(
+    'splToken',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  );
+  umi.programs.add(splTokenProgram);
+  t.is(umi.programs.get('splToken'), splTokenProgram);
+
+  // And given a binding that uses the public key of splToken2022 when requesting splToken.
+  umi.programs.bind(
+    'splToken',
+    publicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb')
+  );
+
+  // When we try to get the splToken program.
+  const fn = () => umi.programs.get('splToken');
+
+  // Then we expect an error to be thrown.
+  t.throws(fn, {
+    message:
+      /The provided program address \[TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\] is not recognized/,
+  });
+});
+
+test('it cannot add a binding that creates a circular dependency', async (t) => {
+  // Given 2 bindings such that programA resolves to programB which resolves to programC.
+  const umi = createUmi();
+  umi.programs.bind('programA', 'programB');
+  umi.programs.bind('programB', 'programC');
+
+  // When we try to add a third binding that would create a circular dependency.
+  const fn = () => umi.programs.bind('programC', 'programA');
+
+  // Then we expect an error to be thrown.
+  t.throws(fn, {
+    message:
+      /Circular binding detected: programC -> programA -> programB -> programC/,
+  });
+});

--- a/packages/umi-program-repository/test/bindings.test.ts
+++ b/packages/umi-program-repository/test/bindings.test.ts
@@ -91,3 +91,28 @@ test('it cannot add a binding that creates a circular dependency', async (t) => 
       /Circular binding detected: programC -> programA -> programB -> programC/,
   });
 });
+
+test('it can unbind an existing bidding', async (t) => {
+  // Given ta binding between two registered programs: splToken and splToken2022.
+  const umi = createUmi();
+  const splTokenProgram: Program = createProgram(
+    'splToken',
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  );
+  const splToken2022Program: Program = createProgram(
+    'splToken2022',
+    'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+  );
+  umi.programs.add(splTokenProgram);
+  umi.programs.add(splToken2022Program);
+  umi.programs.bind('splToken', 'splToken2022');
+  t.is(umi.programs.get('splToken'), splToken2022Program);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+
+  // When we remove the binding.
+  umi.programs.unbind('splToken');
+
+  // Then both program names resolve to their original programs.
+  t.is(umi.programs.get('splToken'), splTokenProgram);
+  t.is(umi.programs.get('splToken2022'), splToken2022Program);
+});

--- a/packages/umi-program-repository/test/clone.test.ts
+++ b/packages/umi-program-repository/test/clone.test.ts
@@ -1,0 +1,23 @@
+import test from 'ava';
+import { createProgram, createUmi } from './_setup';
+
+test('it can clone a program repository', async (t) => {
+  // Given a program repository with one program registered.
+  const umi = createUmi();
+  const programA = createProgram('programA');
+  umi.programs.add(programA);
+  t.is(umi.programs.all().length, 1);
+
+  // When we clone the program repository.
+  const clonedPrograms = umi.programs.clone();
+
+  // Then we get a new repository instance with the same programs.
+  t.not(clonedPrograms, umi.programs);
+  t.is(clonedPrograms.all().length, 1);
+  t.deepEqual(clonedPrograms.all(), [programA]);
+
+  // And adding new programs to the cloned repository does not affect the original.
+  clonedPrograms.add(createProgram('programB'));
+  t.is(clonedPrograms.all().length, 2);
+  t.is(umi.programs.all().length, 1);
+});

--- a/packages/umi-program-repository/test/someFeature.test.ts
+++ b/packages/umi-program-repository/test/someFeature.test.ts
@@ -1,6 +1,0 @@
-import test from 'ava';
-import { defaultProgramRepository } from '../src';
-
-test('example test', async (t) => {
-  t.is(typeof defaultProgramRepository, 'function');
-});

--- a/packages/umi/src/Program.ts
+++ b/packages/umi/src/Program.ts
@@ -59,7 +59,7 @@ export type Program = {
    * A method that returns `true` if the program is available on the given cluster.
    *
    * If the same program is available on multiple clusters but using different public keys,
-   * mulitple Program instances must be registered such that the `isOnCluster` method
+   * multiple Program instances must be registered such that the `isOnCluster` method
    * returns `true` for the appropriate cluster.
    */
   isOnCluster: (cluster: Cluster) => boolean;

--- a/packages/umi/src/ProgramRepositoryInterface.ts
+++ b/packages/umi/src/ProgramRepositoryInterface.ts
@@ -1,8 +1,8 @@
 import type { ClusterFilter } from './Cluster';
 import { InterfaceImplementationMissingError, ProgramError } from './errors';
 import type { ErrorWithLogs, Program } from './Program';
-import { PublicKey, PublicKeyInput } from './PublicKey';
-import { Transaction } from './Transaction';
+import type { PublicKey, PublicKeyInput } from './PublicKey';
+import type { Transaction } from './Transaction';
 
 /**
  * Defines the interface for a program repository.
@@ -61,10 +61,34 @@ export interface ProgramRepositoryInterface {
    * Registers a new program in the repository.
    *
    * @param program The program to register.
-   * @param overrides Whether to override an existing program with the
-   * same name or public key. Defaults to `true`.
+   * @param overrides Whether to register and prioritize
+   * the given program even if a program with the same
+   * public key already exists. Defaults to `true`.
    */
   add(program: Program, overrides?: boolean): void;
+
+  /**
+   * Creates a binding between a name and a program identifier.
+   * This can be used to create redirections or aliases when resolving programs.
+   *
+   * @param abstract The name of the binding.
+   * @param concrete The identifier this binding should resolve to.
+   */
+  bind(abstract: string, concrete: string | PublicKey): void;
+
+  /**
+   * Removes a binding using its name.
+   *
+   * @param abstract The name of the binding to remove.
+   */
+  unbind(abstract: string): void;
+
+  /**
+   * Creates a cloned instance of the repository.
+   *
+   * @returns A new repository instance with the same programs and bindings.
+   */
+  clone(): ProgramRepositoryInterface;
 
   /**
    * Resolves a custom program error from a transaction error.
@@ -96,6 +120,9 @@ export function createNullProgramRepository(): ProgramRepositoryInterface {
     getPublicKey: errorHandler,
     all: errorHandler,
     add: errorHandler,
+    bind: errorHandler,
+    unbind: errorHandler,
+    clone: errorHandler,
     resolveError: errorHandler,
   };
 }


### PR DESCRIPTION
## Program bindings

```js
// Given two registered programs.
umi.programs.add(splTokenProgram); // name === 'splToken'
umi.programs.add(splToken2022Program); // name === 'splToken2022'

// When we bind the former with the latter by name.
umi.programs.bind('splToken', 'splToken2022');

// ...or by public key.
umi.programs.bind('splToken', publicKey('...'));

// Then retrieving the former program resolves to the latter.
umi.programs.get('splToken'); // returns splToken2022Program

// And when we remove the binding.
umi.programs.unbind('splToken');

// Everything is back to normal.
umi.programs.get('splToken'); // returns splTokenProgram
```

## Cloning program repositories

```js
// When we clone a program repository.
const clonedPrograms = umi.programs.clone();

// Then we get a new instance of the program repository such that
// adding new programs to the cloned repository does not affect the original.
clonedPrograms.add({ ... });
clonedPrograms.bind('foo', 'bar');
someFunctionThatRequiresUmi({ ...umi, programs: clonedPrograms });
```