### PR TITLE
feature: compact-u16 serialization

### DIFF
--- a/packages/umi-serializer-beet/src/createBeetSerializer.ts
+++ b/packages/umi-serializer-beet/src/createBeetSerializer.ts
@@ -39,6 +39,7 @@ import {
   NotEnoughBytesError,
 } from './errors';
 import {
+  compactU16,
   i128,
   i16,
   i32,
@@ -685,6 +686,7 @@ export function createBeetSerializer(
     unit,
     u8,
     u16,
+    compactU16,
     u32,
     u64,
     u128,

--- a/packages/umi-serializer-data-view/src/createDataViewSerializer.ts
+++ b/packages/umi-serializer-data-view/src/createDataViewSerializer.ts
@@ -39,6 +39,7 @@ import {
   NotEnoughBytesError,
 } from './errors';
 import {
+  compactU16,
   f32,
   f64,
   i128,
@@ -687,6 +688,7 @@ export function createDataViewSerializer(
     unit,
     u8,
     u16,
+    compactU16,
     u32,
     u64,
     u128,

--- a/packages/umi-serializer-data-view/src/numbers.ts
+++ b/packages/umi-serializer-data-view/src/numbers.ts
@@ -104,6 +104,53 @@ export const u16 = (
   };
 };
 
+export const compactU16 = (
+  options: SingleByteNumberSerializerOptions = {}
+): Serializer<number> => ({
+  description: options.description ?? 'compact-u16',
+  fixedSize: null,
+  maxSize: 3,
+  serialize(value: number): Uint8Array {
+    assertRange('compact-u16', 0, 65535, value);
+    const bytes = [0];
+    for (let ii = 0; ; ii += 1) {
+      // Shift the bits of the value over such that the next 7 bits are at the right edge.
+      const alignedValue = value >> (ii * 7);
+      if (alignedValue === 0) {
+        // No more bits to consume.
+        break;
+      }
+      // Extract those 7 bits using a mask.
+      const nextSevenBits = 0b1111111 & alignedValue;
+      bytes[ii] = nextSevenBits;
+      if (ii > 0) {
+        // Set the continuation bit of the previous slice.
+        bytes[ii - 1] |= 0b10000000;
+      }
+    }
+    return new Uint8Array(bytes);
+  },
+  deserialize(bytes, offset = 0): [number, number] {
+    assertEnoughBytes('compact-u16', bytes.slice(offset), 1);
+    let value = 0;
+    let byteCount = 0;
+    while (
+      ++byteCount // eslint-disable-line no-plusplus
+    ) {
+      const byteIndex = byteCount - 1;
+      const currentByte = bytes[offset + byteIndex];
+      const nextSevenBits = 0b1111111 & currentByte;
+      // Insert the next group of seven bits into the correct slot of the output value.
+      value |= nextSevenBits << (byteIndex * 7);
+      if ((currentByte & 0b10000000) === 0) {
+        // This byte does not have its continuation bit set. We're done.
+        break;
+      }
+    }
+    return [value, byteCount];
+  },
+});
+
 export const i16 = (
   options: NumberSerializerOptions = {}
 ): Serializer<number> => {

--- a/packages/umi-serializer-data-view/test/numbers.test.ts
+++ b/packages/umi-serializer-data-view/test/numbers.test.ts
@@ -154,12 +154,36 @@ function testIntegerDeserialization(
   }
 }
 
+test('compact-u16 serialization', (t) => {
+  const serializer = createDataViewSerializer();
+
+  s(t, serializer.compactU16(), 0n, '00');
+  s(t, serializer.compactU16(), 127n, '7f');
+  s(t, serializer.compactU16(), 128n, '8001');
+  s(t, serializer.compactU16(), 16383n, 'ff7f');
+  s(t, serializer.compactU16(), 16384n, '808001');
+  s(t, serializer.compactU16(), 65535n, 'ffff03');
+
+  t.throws(() => {
+    serializer.compactU16().serialize(-1);
+  });
+  t.throws(() => {
+    serializer.compactU16().serialize(65536);
+  });
+
+  for (let ii = 0; ii <= 0b1111111111111111; ii += 1) {
+    const buffer = serializer.compactU16().serialize(ii);
+    t.is(serializer.compactU16().deserialize(buffer)[0], ii);
+  }
+});
+
 test('description', (t) => {
   const serializer = createDataViewSerializer();
 
   // Little endian.
   t.is(serializer.u8().description, 'u8');
   t.is(serializer.u16().description, 'u16(le)');
+  t.is(serializer.compactU16().description, 'compact-u16');
   t.is(serializer.u32().description, 'u32(le)');
   t.is(serializer.u64().description, 'u64(le)');
   t.is(serializer.u128().description, 'u128(le)');
@@ -199,6 +223,8 @@ test('sizes', (t) => {
   t.is(serializer.u8().maxSize, 1);
   t.is(serializer.u16().fixedSize, 2);
   t.is(serializer.u16().maxSize, 2);
+  t.is(serializer.compactU16().fixedSize, null);
+  t.is(serializer.compactU16().maxSize, 3);
   t.is(serializer.u32().fixedSize, 4);
   t.is(serializer.u32().maxSize, 4);
   t.is(serializer.u64().fixedSize, 8);

--- a/packages/umi/src/SerializerInterface.ts
+++ b/packages/umi/src/SerializerInterface.ts
@@ -152,6 +152,16 @@ export interface SerializerInterface {
   u16: (options?: NumberSerializerOptions) => Serializer<number>;
 
   /**
+   * Creates a serializer that packs 2-byte unsigned integers into 1 byte for values up to 127, 2
+   * bytes for values between 128-16383, and 3 bytes for values between 16384-65535.
+   *
+   * @param options - A set of options for the serializer.
+   */
+  compactU16: (
+    options?: SingleByteNumberSerializerOptions
+  ) => Serializer<number>;
+
+  /**
    * Creates a serializer for 4-bytes unsigned integers.
    *
    * @param options - A set of options for the serializer.
@@ -521,6 +531,7 @@ export function createNullSerializer(): SerializerInterface {
     unit: errorHandler,
     u8: errorHandler,
     u16: errorHandler,
+    compactU16: errorHandler,
     u32: errorHandler,
     u64: errorHandler,
     u128: errorHandler,


### PR DESCRIPTION
feature: compact-u16 serialization
## Summary:

Solana transactions use a special space-saving encoding for u16 values. It's most useful when the typical workload involves values less-than-or-equal-to `127`. You can read all about it [here](https://solana.stackexchange.com/a/2129/75).

In this PR, we introduce a codec for compact-u16.

## Test Plan:

```shell
pnpm test
```
