### PR TITLE
Define PublicKeys as base58 strings

### DIFF
--- a/.changeset/little-planets-kick.md
+++ b/.changeset/little-planets-kick.md
@@ -1,0 +1,11 @@
+---
+'@metaplex-foundation/umi-serializer-data-view': minor
+'@metaplex-foundation/umi-uploader-nft-storage': minor
+'@metaplex-foundation/umi-program-repository': minor
+'@metaplex-foundation/umi-serializer-beet': minor
+'@metaplex-foundation/umi-uploader-bundlr': minor
+'@metaplex-foundation/umi-web3js-adapters': minor
+'@metaplex-foundation/umi-eddsa-web3js': minor
+---
+
+Use PublicKeys as base58 strings. See `@metaplex-foundation/umi` changelog for more details.

--- a/.changeset/nine-trainers-drop.md
+++ b/.changeset/nine-trainers-drop.md
@@ -1,0 +1,53 @@
+---
+'@metaplex-foundation/umi-serializer-data-view': minor
+'@metaplex-foundation/umi-uploader-nft-storage': minor
+'@metaplex-foundation/umi-program-repository': minor
+'@metaplex-foundation/umi-serializer-beet': minor
+'@metaplex-foundation/umi-uploader-bundlr': minor
+'@metaplex-foundation/umi-web3js-adapters': minor
+'@metaplex-foundation/umi-eddsa-web3js': minor
+'@metaplex-foundation/umi': minor
+---
+
+Define PublicKeys as base58 strings
+
+See (PR #62)[https://github.com/metaplex-foundation/umi/pull/62].
+
+The `PublicKey` type is now a `string` instead of a `{ bytes: Uint8Array }`. This was done to:
+
+- make the end-user API simpler.
+- make public keys "pure" values that can easily be shared and logged.
+- make Umi's API closer to the new web3.js library (See [the `@solana/keys` package](https://github.com/solana-labs/solana-web3.js/blob/6524b01189cd4917da62fe78a33fef58bd692986/packages/keys/src/base58.ts)).
+
+If you are already using the `publicKey` helper to create public keys, your code should continue working as-is. Otherwise, you will need to pass in the base58 representation of your public keys instead of the previous object representation.
+
+```ts
+// Before.
+const pubkeyA = publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
+const bytesOfPubkeyB = new Uint8Array(Array(32).fill(0));
+const pubkeyB = { bytes: bytesOfPubkeyB };
+
+// After.
+const pubkeyA = publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'); // ✅ No changes needed.
+const bytesOfPubkeyB = new Uint8Array(Array(32).fill(0));
+const pubkeyB = publicKey(bytesOfPubkeyB); // ⚠️ Use the `publicKey` helper to convert to a `PublicKey` string.
+const pubkeyB = publicKey('11111111111111111111111111111111'); // ⚠️ Or pass in the base58 string directly.
+```
+
+Note that the `Pda` type has also been adjusted since it can no longer extend the `PublicKey` type (as it is now a primitive value and not an object). Instead, the `Pda` type is now defined as the following tuple `[PublicKey, number]`. If you are using Kinobi-generated library, they have been updated to ensure that you can pass either a `PublicKey` or a `Pda` in various generated method to avoid any breaking change. That being said, if you are using PDAs directly you need to update your code as showed below:
+
+```ts
+// Before.
+const pdaA = findSomePda(umi, seedsA);
+await fetchSomeAccount(umi, pdaA);
+
+const pdaB = findSomePda(umi, seedsB);
+await umi.rpc.getAccount(pdaB);
+
+// After.
+const pdaA = findSomePda(umi, seedsA);
+await fetchSomeAccount(umi, pdaA); // ✅ No changes needed as generated methods now accept PublicKey | Pda.
+
+const [publicKeyB] = findSomePda(umi, seedsB); // ⚠️ Destructure the Pda to get the PublicKey...
+await umi.rpc.getAccount(publicKeyB); // ...because `getAccount` requires a `PublicKey`.
+```

--- a/.changeset/nine-trainers-drop.md
+++ b/.changeset/nine-trainers-drop.md
@@ -23,11 +23,11 @@ const pubkeyB = { bytes: bytesOfPubkeyB };
 // After.
 const pubkeyA = publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'); // ✅ No changes needed.
 const bytesOfPubkeyB = new Uint8Array(Array(32).fill(0));
-const pubkeyB = publicKey(bytesOfPubkeyB); // ⚠️ Use the `publicKey` helper to convert to a `PublicKey` string.
-const pubkeyB = publicKey('11111111111111111111111111111111'); // ⚠️ Or pass in the base58 string directly.
+const pubkeyB = publicKey(bytesOfPubkeyB); // 🚧 Use the `publicKey` helper to convert to a `PublicKey` string.
+const pubkeyB = publicKey('11111111111111111111111111111111'); // 🚧 Or pass in the base58 string directly.
 ```
 
-Note that the `Pda` type has also been adjusted since it can no longer extend the `PublicKey` type (as it is now a primitive value and not an object). Instead, the `Pda` type is now defined as the following tuple `[PublicKey, number]`. If you are using Kinobi-generated library, they have been updated to ensure that you can pass either a `PublicKey` or a `Pda` in various generated method to avoid any breaking change. That being said, if you are using PDAs directly you need to update your code as showed below:
+Note that the `Pda` type has also been adjusted since it can no longer extend the `PublicKey` type (as it is now a primitive value and not an object). Instead, the `Pda` type is now defined as the following tuple `[PublicKey, number]`. If you are using a Kinobi-generated library, they have been updated to ensure that you can pass either a `PublicKey` or a `Pda` in various generated method to avoid any breaking change. That being said, if you are using PDAs directly you may need to update your code as showed below:
 
 ```ts
 // Before.
@@ -41,6 +41,6 @@ await umi.rpc.getAccount(pdaB);
 const pdaA = findSomePda(umi, seedsA);
 await fetchSomeAccount(umi, pdaA); // ✅ No changes needed as generated methods now accept PublicKey | Pda.
 
-const [publicKeyB] = findSomePda(umi, seedsB); // ⚠️ Destructure the Pda to get the PublicKey...
+const [publicKeyB] = findSomePda(umi, seedsB); // 🚧 Destructure the Pda to get the PublicKey...
 await umi.rpc.getAccount(publicKeyB); // ...because `getAccount` requires a `PublicKey`.
 ```

--- a/.changeset/nine-trainers-drop.md
+++ b/.changeset/nine-trainers-drop.md
@@ -1,11 +1,4 @@
 ---
-'@metaplex-foundation/umi-serializer-data-view': minor
-'@metaplex-foundation/umi-uploader-nft-storage': minor
-'@metaplex-foundation/umi-program-repository': minor
-'@metaplex-foundation/umi-serializer-beet': minor
-'@metaplex-foundation/umi-uploader-bundlr': minor
-'@metaplex-foundation/umi-web3js-adapters': minor
-'@metaplex-foundation/umi-eddsa-web3js': minor
 '@metaplex-foundation/umi': minor
 ---
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -62,7 +62,7 @@ builder = builder.prepend(myWrappedInstruction);
 Note that either of these methods also accepts other transaction builders and will merge them into the current one. In practice, this means program libraries can write (or [auto-generate](./kinobi.md)) their own helper methods that return transaction builders so they can be composed together by the end-user.
 
 ```ts
-import { transferSol, addMemo } from '@metaplex-foundation/mpl-essentials';
+import { transferSol, addMemo } from '@metaplex-foundation/mpl-toolbox';
 import { createNft } from '@metaplex-foundation/mpl-token-metadata';
 
 let builder = transactionBuilder()
@@ -187,10 +187,10 @@ const myLut: AddressLookupTableInput = {
 builder = builder.setAddressLookupTables([myLut]);
 ```
 
-To create an address lookup table, you might be interested in the `@metaplex-foundation/mpl-essentials` package which provides helpers for creating them.
+To create an address lookup table, you might be interested in the `@metaplex-foundation/mpl-toolbox` package which provides helpers for creating them.
 
 ```ts
-import { createLut } from '@metaplex-foundation/mpl-essentials';
+import { createLut } from '@metaplex-foundation/mpl-toolbox';
 
 // Create a lookup table.
 const [lutBuilder, lut] = createLut(umi, {

--- a/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
+++ b/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
@@ -36,7 +36,7 @@ export function createWeb3JsEddsa(): EddsaInterface {
       seeds,
       toWeb3JsPublicKey(publicKey(programId))
     );
-    return [fromWeb3JsPublicKey(key), bump];
+    return [fromWeb3JsPublicKey(key), bump] as Pda;
   };
 
   const sign = (message: Uint8Array, keypair: Keypair): Uint8Array =>

--- a/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
+++ b/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
@@ -4,6 +4,7 @@ import {
   Pda,
   publicKey,
   PublicKey,
+  publicKeyBytes,
   PublicKeyInput,
 } from '@metaplex-foundation/umi';
 import {
@@ -35,7 +36,7 @@ export function createWeb3JsEddsa(): EddsaInterface {
       seeds,
       toWeb3JsPublicKey(publicKey(programId))
     );
-    return { ...fromWeb3JsPublicKey(key), bump };
+    return { publicKey: fromWeb3JsPublicKey(key), bump };
   };
 
   const sign = (message: Uint8Array, keypair: Keypair): Uint8Array =>
@@ -45,7 +46,7 @@ export function createWeb3JsEddsa(): EddsaInterface {
     message: Uint8Array,
     signature: Uint8Array,
     publicKey: PublicKey
-  ): boolean => ed25519.verify(signature, message, publicKey.bytes);
+  ): boolean => ed25519.verify(signature, message, publicKeyBytes(publicKey));
 
   return {
     generateKeypair,

--- a/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
+++ b/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
@@ -36,7 +36,7 @@ export function createWeb3JsEddsa(): EddsaInterface {
       seeds,
       toWeb3JsPublicKey(publicKey(programId))
     );
-    return { publicKey: fromWeb3JsPublicKey(key), bump };
+    return [fromWeb3JsPublicKey(key), bump];
   };
 
   const sign = (message: Uint8Array, keypair: Keypair): Uint8Array =>

--- a/packages/umi-program-repository/src/createDefaultProgramRepository.ts
+++ b/packages/umi-program-repository/src/createDefaultProgramRepository.ts
@@ -32,9 +32,9 @@ export function createDefaultProgramRepository(
   ): boolean => {
     const programs = all(clusterFilter);
     const resolvedIdentifier = resolveBinding(identifier);
-    return typeof resolvedIdentifier === 'string'
-      ? programs.some((p) => p.name === resolvedIdentifier)
-      : programs.some((p) => samePublicKey(p.publicKey, resolvedIdentifier));
+    return isPublicKey(resolvedIdentifier)
+      ? programs.some((p) => samePublicKey(p.publicKey, resolvedIdentifier))
+      : programs.some((p) => p.name === resolvedIdentifier);
   };
 
   const get = <T extends Program = Program>(
@@ -44,10 +44,9 @@ export function createDefaultProgramRepository(
     const cluster = resolveClusterFilter(clusterFilter);
     const programs = all(clusterFilter);
     const resolvedIdentifier = resolveBinding(identifier);
-    const program =
-      typeof resolvedIdentifier === 'string'
-        ? programs.find((p) => p.name === resolvedIdentifier)
-        : programs.find((p) => samePublicKey(p.publicKey, resolvedIdentifier));
+    const program = isPublicKey(resolvedIdentifier)
+      ? programs.find((p) => samePublicKey(p.publicKey, resolvedIdentifier))
+      : programs.find((p) => p.name === resolvedIdentifier);
 
     if (!program) {
       throw new ProgramNotRecognizedError(resolvedIdentifier, cluster);

--- a/packages/umi-program-repository/src/createDefaultProgramRepository.ts
+++ b/packages/umi-program-repository/src/createDefaultProgramRepository.ts
@@ -10,7 +10,6 @@ import {
   publicKey,
   PublicKey,
   PublicKeyInput,
-  samePublicKey,
   Transaction,
 } from '@metaplex-foundation/umi';
 import {
@@ -33,7 +32,7 @@ export function createDefaultProgramRepository(
     const programs = all(clusterFilter);
     const resolvedIdentifier = resolveBinding(identifier);
     return isPublicKey(resolvedIdentifier)
-      ? programs.some((p) => samePublicKey(p.publicKey, resolvedIdentifier))
+      ? programs.some((p) => p.publicKey === resolvedIdentifier)
       : programs.some((p) => p.name === resolvedIdentifier);
   };
 
@@ -45,7 +44,7 @@ export function createDefaultProgramRepository(
     const programs = all(clusterFilter);
     const resolvedIdentifier = resolveBinding(identifier);
     const program = isPublicKey(resolvedIdentifier)
-      ? programs.find((p) => samePublicKey(p.publicKey, resolvedIdentifier))
+      ? programs.find((p) => p.publicKey === resolvedIdentifier)
       : programs.find((p) => p.name === resolvedIdentifier);
 
     if (!program) {

--- a/packages/umi-program-repository/src/errors.ts
+++ b/packages/umi-program-repository/src/errors.ts
@@ -1,11 +1,11 @@
 import {
   Cluster,
-  base58PublicKey,
   Program,
   ProgramError,
   PublicKey,
   SdkError,
   UnderlyingProgramError,
+  isPublicKey,
 } from '@metaplex-foundation/umi';
 
 export class ProgramNotRecognizedError extends SdkError {
@@ -16,8 +16,8 @@ export class ProgramNotRecognizedError extends SdkError {
   readonly cluster: Cluster | '*';
 
   constructor(identifier: string | PublicKey, cluster: Cluster | '*') {
-    const isName = typeof identifier === 'string';
-    const toString = isName ? identifier : base58PublicKey(identifier);
+    const isName = !isPublicKey(identifier);
+    const toString = isName ? identifier : identifier;
     const clusterString = cluster === '*' ? 'any' : `the [${cluster}]`;
     const message =
       `The provided program ${isName ? 'name' : 'address'} [${toString}] ` +
@@ -38,7 +38,7 @@ export class ProgramErrorNotRecognizedError extends ProgramError {
     const ofCode = cause.code ? ` of code [${cause.code}]` : '';
     const message =
       `The program [${program.name}] ` +
-      `at address [${base58PublicKey(program.publicKey)}] ` +
+      `at address [${program.publicKey}] ` +
       `raised an error${ofCode} ` +
       `that is not recognized by the programs registered on the SDK. ` +
       `Please check the underlying program error below for more details.`;

--- a/packages/umi-serializer-beet/src/pubkey.ts
+++ b/packages/umi-serializer-beet/src/pubkey.ts
@@ -4,6 +4,7 @@ import {
   PublicKeyInput,
   PublicKeySerializerOptions,
   Serializer,
+  publicKeyBytes,
 } from '@metaplex-foundation/umi';
 import { DeserializingEmptyBufferError, BeetSerializerError } from './errors';
 
@@ -14,7 +15,7 @@ export function publicKey(
     description: options.description ?? 'publicKey',
     fixedSize: 32,
     maxSize: 32,
-    serialize: (value: PublicKeyInput) => toPublicKey(value).bytes,
+    serialize: (value: PublicKeyInput) => publicKeyBytes(toPublicKey(value)),
     deserialize: (bytes: Uint8Array, offset = 0) => {
       if (bytes.slice(offset).length === 0) {
         throw new DeserializingEmptyBufferError('publicKey');

--- a/packages/umi-serializer-beet/src/pubkey.ts
+++ b/packages/umi-serializer-beet/src/pubkey.ts
@@ -1,12 +1,13 @@
 import {
-  publicKey as toPublicKey,
+  PUBLIC_KEY_LENGTH,
   PublicKey,
   PublicKeyInput,
   PublicKeySerializerOptions,
   Serializer,
   publicKeyBytes,
+  publicKey as toPublicKey,
 } from '@metaplex-foundation/umi';
-import { DeserializingEmptyBufferError, BeetSerializerError } from './errors';
+import { DeserializingEmptyBufferError, NotEnoughBytesError } from './errors';
 
 export function publicKey(
   options: PublicKeySerializerOptions = {}
@@ -17,13 +18,15 @@ export function publicKey(
     maxSize: 32,
     serialize: (value: PublicKeyInput) => publicKeyBytes(toPublicKey(value)),
     deserialize: (bytes: Uint8Array, offset = 0) => {
-      if (bytes.slice(offset).length === 0) {
+      const pubkeyBytes = bytes.slice(offset, offset + 32);
+      if (pubkeyBytes.length === 0) {
         throw new DeserializingEmptyBufferError('publicKey');
       }
-      const pubkeyBytes = bytes.slice(offset, offset + 32);
-      if (pubkeyBytes.length < 32) {
-        throw new BeetSerializerError(
-          `Serializer [publicKey] expected 32 bytes, got ${pubkeyBytes.length}.`
+      if (pubkeyBytes.length < PUBLIC_KEY_LENGTH) {
+        throw new NotEnoughBytesError(
+          'publicKey',
+          PUBLIC_KEY_LENGTH,
+          pubkeyBytes.length
         );
       }
       return [toPublicKey(pubkeyBytes), offset + 32];

--- a/packages/umi-serializer-beet/test/publicKey.test.ts
+++ b/packages/umi-serializer-beet/test/publicKey.test.ts
@@ -1,20 +1,22 @@
 import test from 'ava';
-import { base16, publicKey as toPublicKey } from '@metaplex-foundation/umi';
+import {
+  base16,
+  publicKeyBytes,
+  publicKey as toPublicKey,
+} from '@metaplex-foundation/umi';
 import { s, d } from './_helpers';
 import { publicKey } from '../src/pubkey';
 
 test('serialization', (t) => {
   const keyA = toPublicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
-  const keyABytes = base16.deserialize(keyA.bytes)[0];
+  const keyABytes = base16.deserialize(publicKeyBytes(keyA))[0];
   s(t, publicKey(), keyA, keyABytes);
 
   const keyB = toPublicKey('11111111111111111111111111111111');
-  const keyBBytes = base16.deserialize(keyB.bytes)[0];
+  const keyBBytes = base16.deserialize(publicKeyBytes(keyB))[0];
   s(t, publicKey(), keyB, keyBBytes);
 
-  const throwExpectation = {
-    message: (m: string) => m.includes('Invalid public key'),
-  };
+  const throwExpectation = { name: 'InvalidPublicKeyError' };
   t.throws(() => publicKey().serialize(''), throwExpectation);
   t.throws(() => publicKey().serialize('L'), throwExpectation);
   t.throws(() => publicKey().serialize('x'.repeat(32)), throwExpectation);
@@ -22,11 +24,11 @@ test('serialization', (t) => {
 
 test('deserialization', (t) => {
   const keyA = toPublicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
-  const keyABytes = base16.deserialize(keyA.bytes)[0];
+  const keyABytes = base16.deserialize(publicKeyBytes(keyA))[0];
   d(t, publicKey(), keyABytes, keyA, 32);
 
   const keyB = toPublicKey('11111111111111111111111111111111');
-  const keyBBytes = base16.deserialize(keyB.bytes)[0];
+  const keyBBytes = base16.deserialize(publicKeyBytes(keyB))[0];
   d(t, publicKey(), keyBBytes, keyB, 32);
 });
 

--- a/packages/umi-serializer-data-view/src/pubkey.ts
+++ b/packages/umi-serializer-data-view/src/pubkey.ts
@@ -1,15 +1,13 @@
 import {
-  publicKey as toPublicKey,
+  PUBLIC_KEY_LENGTH,
   PublicKey,
   PublicKeyInput,
   PublicKeySerializerOptions,
   Serializer,
   publicKeyBytes,
+  publicKey as toPublicKey,
 } from '@metaplex-foundation/umi';
-import {
-  DeserializingEmptyBufferError,
-  DataViewSerializerError,
-} from './errors';
+import { DeserializingEmptyBufferError, NotEnoughBytesError } from './errors';
 
 export function publicKey(
   options: PublicKeySerializerOptions = {}
@@ -20,13 +18,15 @@ export function publicKey(
     maxSize: 32,
     serialize: (value: PublicKeyInput) => publicKeyBytes(toPublicKey(value)),
     deserialize: (bytes: Uint8Array, offset = 0) => {
-      if (bytes.slice(offset).length === 0) {
+      const pubkeyBytes = bytes.slice(offset, offset + 32);
+      if (pubkeyBytes.length === 0) {
         throw new DeserializingEmptyBufferError('publicKey');
       }
-      const pubkeyBytes = bytes.slice(offset, offset + 32);
-      if (pubkeyBytes.length < 32) {
-        throw new DataViewSerializerError(
-          `Serializer [publicKey] expected 32 bytes, got ${pubkeyBytes.length}.`
+      if (pubkeyBytes.length < PUBLIC_KEY_LENGTH) {
+        throw new NotEnoughBytesError(
+          'publicKey',
+          PUBLIC_KEY_LENGTH,
+          pubkeyBytes.length
         );
       }
       return [toPublicKey(pubkeyBytes), offset + 32];

--- a/packages/umi-serializer-data-view/src/pubkey.ts
+++ b/packages/umi-serializer-data-view/src/pubkey.ts
@@ -4,6 +4,7 @@ import {
   PublicKeyInput,
   PublicKeySerializerOptions,
   Serializer,
+  publicKeyBytes,
 } from '@metaplex-foundation/umi';
 import {
   DeserializingEmptyBufferError,
@@ -17,7 +18,7 @@ export function publicKey(
     description: options.description ?? 'publicKey',
     fixedSize: 32,
     maxSize: 32,
-    serialize: (value: PublicKeyInput) => toPublicKey(value).bytes,
+    serialize: (value: PublicKeyInput) => publicKeyBytes(toPublicKey(value)),
     deserialize: (bytes: Uint8Array, offset = 0) => {
       if (bytes.slice(offset).length === 0) {
         throw new DeserializingEmptyBufferError('publicKey');

--- a/packages/umi-serializer-data-view/test/publicKey.test.ts
+++ b/packages/umi-serializer-data-view/test/publicKey.test.ts
@@ -1,21 +1,23 @@
 import test from 'ava';
-import { base16, publicKey as toPublicKey } from '@metaplex-foundation/umi';
+import {
+  base16,
+  publicKeyBytes,
+  publicKey as toPublicKey,
+} from '@metaplex-foundation/umi';
 
 import { s, d } from './_helpers';
 import { publicKey } from '../src/pubkey';
 
 test('serialization', (t) => {
   const keyA = toPublicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
-  const keyABytes = base16.deserialize(keyA.bytes)[0];
+  const keyABytes = base16.deserialize(publicKeyBytes(keyA))[0];
   s(t, publicKey(), keyA, keyABytes);
 
   const keyB = toPublicKey('11111111111111111111111111111111');
-  const keyBBytes = base16.deserialize(keyB.bytes)[0];
+  const keyBBytes = base16.deserialize(publicKeyBytes(keyB))[0];
   s(t, publicKey(), keyB, keyBBytes);
 
-  const throwExpectation = {
-    message: (m: string) => m.includes('Invalid public key'),
-  };
+  const throwExpectation = { name: 'InvalidPublicKeyError' };
   t.throws(() => publicKey().serialize(''), throwExpectation);
   t.throws(() => publicKey().serialize('L'), throwExpectation);
   t.throws(() => publicKey().serialize('x'.repeat(32)), throwExpectation);
@@ -23,11 +25,11 @@ test('serialization', (t) => {
 
 test('deserialization', (t) => {
   const keyA = toPublicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
-  const keyABytes = base16.deserialize(keyA.bytes)[0];
+  const keyABytes = base16.deserialize(publicKeyBytes(keyA))[0];
   d(t, publicKey(), keyABytes, keyA, 32);
 
   const keyB = toPublicKey('11111111111111111111111111111111');
-  const keyBBytes = base16.deserialize(keyB.bytes)[0];
+  const keyBBytes = base16.deserialize(publicKeyBytes(keyB))[0];
   d(t, publicKey(), keyBBytes, keyB, 32);
 });
 

--- a/packages/umi-uploader-bundlr/src/createBundlrUploader.ts
+++ b/packages/umi-uploader-bundlr/src/createBundlrUploader.ts
@@ -1,21 +1,21 @@
 // eslint-disable-next-line import/no-named-default
 import type { default as NodeBundlr, WebBundlr } from '@bundlr-network/client';
 import {
-  base58,
   Commitment,
   Context,
-  createGenericFileFromJson,
-  createSignerFromKeypair,
   GenericFile,
   GenericFileTag,
-  isKeypairSigner,
   Keypair,
-  lamports,
-  samePublicKey,
   Signer,
-  signTransaction,
   SolAmount,
   UploaderInterface,
+  base58,
+  createGenericFileFromJson,
+  createSignerFromKeypair,
+  isKeypairSigner,
+  lamports,
+  publicKey,
+  signTransaction,
 } from '@metaplex-foundation/umi';
 import {
   fromWeb3JsKeypair,
@@ -214,7 +214,10 @@ export function createBundlrUploader(
   const getBundlr = async (): Promise<WebBundlr | NodeBundlr> => {
     const oldPayer = _bundlr?.getSigner().publicKey;
     const newPayer = options.payer ?? context.payer;
-    if (oldPayer && !samePublicKey(new Uint8Array(oldPayer), newPayer)) {
+    if (
+      oldPayer &&
+      publicKey(new Uint8Array(oldPayer)) !== newPayer.publicKey
+    ) {
       _bundlr = null;
     }
 

--- a/packages/umi-uploader-nft-storage/src/createNftStorageUploader.ts
+++ b/packages/umi-uploader-nft-storage/src/createNftStorageUploader.ts
@@ -6,6 +6,7 @@ import {
   getBytesFromGenericFiles,
   isKeypairSigner,
   lamports,
+  publicKeyBytes,
   Signer,
   SolAmount,
   UploaderInterface,
@@ -60,7 +61,7 @@ export function createNftStorageUploader(
       ? NFTStorageMetaplexor.withSecretKey(signer.secretKey, authOptions)
       : NFTStorageMetaplexor.withSigner(
           signer.signMessage.bind(signer),
-          signer.publicKey.bytes,
+          publicKeyBytes(signer.publicKey),
           authOptions
         );
   };

--- a/packages/umi-web3js-adapters/src/Keypair.ts
+++ b/packages/umi-web3js-adapters/src/Keypair.ts
@@ -1,4 +1,4 @@
-import { Keypair } from '@metaplex-foundation/umi';
+import { Keypair, publicKeyBytes } from '@metaplex-foundation/umi';
 import { Keypair as Web3JsKeypair } from '@solana/web3.js';
 import { fromWeb3JsPublicKey } from './PublicKey';
 
@@ -11,7 +11,7 @@ export function fromWeb3JsKeypair(keypair: Web3JsKeypair): Keypair {
 
 export function toWeb3JsKeypair(keypair: Keypair): Web3JsKeypair {
   return new Web3JsKeypair({
-    publicKey: keypair.publicKey.bytes,
+    publicKey: publicKeyBytes(keypair.publicKey),
     secretKey: keypair.secretKey,
   });
 }

--- a/packages/umi-web3js-adapters/src/PublicKey.ts
+++ b/packages/umi-web3js-adapters/src/PublicKey.ts
@@ -2,7 +2,7 @@ import { PublicKey } from '@metaplex-foundation/umi';
 import { PublicKey as Web3JsPublicKey } from '@solana/web3.js';
 
 export function fromWeb3JsPublicKey(publicKey: Web3JsPublicKey): PublicKey {
-  return publicKey.toBase58();
+  return publicKey.toBase58() as PublicKey;
 }
 
 export function toWeb3JsPublicKey(publicKey: PublicKey): Web3JsPublicKey {

--- a/packages/umi-web3js-adapters/src/PublicKey.ts
+++ b/packages/umi-web3js-adapters/src/PublicKey.ts
@@ -2,9 +2,9 @@ import { PublicKey } from '@metaplex-foundation/umi';
 import { PublicKey as Web3JsPublicKey } from '@solana/web3.js';
 
 export function fromWeb3JsPublicKey(publicKey: Web3JsPublicKey): PublicKey {
-  return { bytes: publicKey.toBytes() };
+  return publicKey.toBase58();
 }
 
 export function toWeb3JsPublicKey(publicKey: PublicKey): Web3JsPublicKey {
-  return new Web3JsPublicKey(publicKey.bytes);
+  return new Web3JsPublicKey(publicKey);
 }

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
-    "@solana/keys": "2.0.0-experimental.7d8a778",
     "ava": "^5.1.0"
   },
   "publishConfig": {

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
+    "@solana/keys": "2.0.0-experimental.7d8a778",
     "ava": "^5.1.0"
   },
   "publishConfig": {

--- a/packages/umi/src/GpaBuilder.ts
+++ b/packages/umi/src/GpaBuilder.ts
@@ -1,12 +1,7 @@
 import type { RpcAccount } from './Account';
 import type { Context } from './Context';
 import { SdkError } from './errors';
-import {
-  base58PublicKey,
-  isPublicKey,
-  publicKey,
-  PublicKey,
-} from './PublicKey';
+import { publicKey, PublicKey } from './PublicKey';
 import type {
   RpcDataFilter,
   RpcDataSlice,
@@ -140,8 +135,6 @@ export class GpaBuilder<
       typeof data === 'boolean'
     ) {
       bytes = base10.serialize(BigInt(data).toString());
-    } else if (isPublicKey(data)) {
-      bytes = new Uint8Array(data.bytes);
     } else {
       bytes = new Uint8Array(data);
     }
@@ -215,7 +208,7 @@ export class GpaBuilder<
           `Following a getProgramAccount call, you are trying to use an ` +
           `account's data (or a slice of it) as a public key. ` +
           `However, we encountered an account ` +
-          `[${base58PublicKey(account.publicKey)}] whose data ` +
+          `[${account.publicKey}] whose data ` +
           `[base64=${base64.deserialize(account.data)}] ` +
           `is not a valid public key.`;
         throw new SdkError(message);

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -1,4 +1,3 @@
-import type { Base58EncodedAddress } from '@solana/keys';
 import { InvalidPublicKeyError } from './errors';
 import { base58 } from './utils';
 
@@ -12,8 +11,9 @@ export const PUBLIC_KEY_LENGTH = 32;
  * Defines a public key as a base58 string.
  * @category Signers and PublicKeys
  */
-export type PublicKey<TAddress extends string = string> =
-  Base58EncodedAddress<TAddress>;
+export type PublicKey<TAddress extends string = string> = TAddress & {
+  readonly __publicKey: unique symbol;
+};
 
 /**
  * Defines a Program-Derived Address.

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -86,9 +86,14 @@ export const defaultPublicKey = (): PublicKey =>
  * Whether the given value is a valid public key.
  * @category Signers and PublicKeys
  */
-export const isPublicKey = (value: any): value is PublicKey =>
-  typeof value === 'string' &&
-  base58.serialize(value).length === PUBLIC_KEY_LENGTH;
+export const isPublicKey = (value: any): value is PublicKey => {
+  try {
+    assertPublicKey(value);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
 
 /**
  * Whether the given value is a valid program-derived address.
@@ -104,8 +109,28 @@ export const isPda = (value: any): value is Pda =>
  * @category Signers and PublicKeys
  */
 export function assertPublicKey(value: any): asserts value is PublicKey {
-  if (!isPublicKey(value)) {
-    throw new InvalidPublicKeyError(value);
+  // Check value type.
+  if (typeof value !== 'string') {
+    throw new InvalidPublicKeyError(value, 'Public keys must be strings.');
+  }
+
+  // Check base58 encoding.
+  let bytes: Uint8Array;
+  try {
+    bytes = base58.serialize(value);
+  } catch (error) {
+    throw new InvalidPublicKeyError(
+      value,
+      'Public keys must be base58 encoded.'
+    );
+  }
+
+  // Check byte length.
+  if (bytes.length !== PUBLIC_KEY_LENGTH) {
+    throw new InvalidPublicKeyError(
+      value,
+      `Public keys must be ${PUBLIC_KEY_LENGTH} bytes.`
+    );
   }
 }
 

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -114,6 +114,14 @@ export function assertPublicKey(value: any): asserts value is PublicKey {
     throw new InvalidPublicKeyError(value, 'Public keys must be strings.');
   }
 
+  // Check string length to avoid unnecessary base58 decoding.
+  if (value.length < 32 || value.length > 44) {
+    throw new InvalidPublicKeyError(
+      value,
+      'Public keys must be between 32 and 44 characters.'
+    );
+  }
+
   // Check base58 encoding.
   let bytes: Uint8Array;
   try {

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -11,7 +11,7 @@ export const PUBLIC_KEY_LENGTH = 32;
  * Defines a public key as a base58 string.
  * @category Signers and PublicKeys
  */
-export type PublicKey = string;
+export type PublicKey = string & { readonly __publicKey: unique symbol };
 
 /**
  * Defines a Program-Derived Address.
@@ -21,7 +21,7 @@ export type PublicKey = string;
  *
  * @category Signers and PublicKeys
  */
-export type Pda = [PublicKey, number];
+export type Pda = [PublicKey, number] & { readonly __pda: unique symbol };
 
 /**
  * Defines all the possible inputs for creating a public key.

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -43,8 +43,7 @@ export type HasPublicKey = { publicKey: PublicKey };
  *
  * @category Signers and PublicKeys
  */
-export type Pda = {
-  readonly publicKey: PublicKey;
+export type Pda = HasPublicKey & {
   readonly bump: number;
 };
 
@@ -163,7 +162,7 @@ export const uniquePublicKeys = (publicKeys: PublicKey[]): PublicKey[] => [
  * Converts the given public key to a Uint8Array.
  * @category Signers and PublicKeys
  */
-export const publicKeyBytes = (key: PublicKeyInput): Uint8Array =>
+export const publicKeyBytes = (key: PublicKeyInput): PublicKeyBytes =>
   base58.serialize(publicKey(key));
 
 /**

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -12,8 +12,7 @@ export const PUBLIC_KEY_LENGTH = 32;
  * Defines a public key as a base58 string.
  * @category Signers and PublicKeys
  */
-export type PublicKey = string &
-  Base58EncodedAddress & { readonly __publicKey: unique symbol };
+export type PublicKey = Base58EncodedAddress;
 
 /**
  * Defines a Program-Derived Address.

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -61,7 +61,7 @@ export const publicKey = (input: PublicKeyInput): PublicKey => {
   else if (typeof input === 'object' && 'publicKey' in input) {
     key = input.publicKey;
   }
-  // Web3JS-compatible PublicKey.
+  // Legacy Web3JS-compatible PublicKey.
   else if (typeof input === 'object' && 'toBase58' in input) {
     key = input.toBase58();
   }

--- a/packages/umi/src/PublicKey.ts
+++ b/packages/umi/src/PublicKey.ts
@@ -1,3 +1,4 @@
+import type { Base58EncodedAddress } from '@solana/keys';
 import { InvalidPublicKeyError } from './errors';
 import { base58 } from './utils';
 
@@ -11,7 +12,8 @@ export const PUBLIC_KEY_LENGTH = 32;
  * Defines a public key as a base58 string.
  * @category Signers and PublicKeys
  */
-export type PublicKey = string & { readonly __publicKey: unique symbol };
+export type PublicKey = string &
+  Base58EncodedAddress & { readonly __publicKey: unique symbol };
 
 /**
  * Defines a Program-Derived Address.

--- a/packages/umi/src/Signer.ts
+++ b/packages/umi/src/Signer.ts
@@ -1,4 +1,4 @@
-import { Pda, PublicKey, samePublicKey } from './PublicKey';
+import { PublicKey, PublicKeyInput, samePublicKey } from './PublicKey';
 import { Transaction } from './Transaction';
 import { uniqueBy } from './utils';
 
@@ -84,7 +84,7 @@ export const signAllTransactions = async (
  * Whether the provided value is a `Signer`.
  * @category Signers and PublicKeys
  */
-export const isSigner = (value: PublicKey | Pda | Signer): value is Signer =>
+export const isSigner = (value: PublicKeyInput | Signer): value is Signer =>
   typeof value === 'object' && 'publicKey' in value && 'signMessage' in value;
 
 /**

--- a/packages/umi/src/Signer.ts
+++ b/packages/umi/src/Signer.ts
@@ -1,4 +1,4 @@
-import { PublicKey, PublicKeyInput, samePublicKey } from './PublicKey';
+import { PublicKey, PublicKeyInput } from './PublicKey';
 import { Transaction } from './Transaction';
 import { uniqueBy } from './utils';
 
@@ -8,13 +8,15 @@ import { uniqueBy } from './utils';
  */
 export interface Signer {
   /** The public key of the Signer. */
-  publicKey: PublicKey;
+  readonly publicKey: PublicKey;
   /** Signs the given message. */
-  signMessage(message: Uint8Array): Promise<Uint8Array>;
+  readonly signMessage: (message: Uint8Array) => Promise<Uint8Array>;
   /** Signs the given transaction. */
-  signTransaction(transaction: Transaction): Promise<Transaction>;
+  readonly signTransaction: (transaction: Transaction) => Promise<Transaction>;
   /** Signs all the given transactions at once. */
-  signAllTransactions(transactions: Transaction[]): Promise<Transaction[]>;
+  readonly signAllTransactions: (
+    transactions: Transaction[]
+  ) => Promise<Transaction[]>;
 }
 
 /**
@@ -47,8 +49,8 @@ export const signAllTransactions = async (
   const signersWithTransactions = transactionsWithSigners.reduce(
     (all, { signers }, index) => {
       signers.forEach((signer) => {
-        const item = all.find((item) =>
-          samePublicKey(item.signer.publicKey, signer.publicKey)
+        const item = all.find(
+          (item) => item.signer.publicKey === signer.publicKey
         );
         if (item) {
           item.indices.push(index);
@@ -92,7 +94,7 @@ export const isSigner = (value: PublicKeyInput | Signer): value is Signer =>
  * @category Signers and PublicKeys
  */
 export const uniqueSigners = (signers: Signer[]): Signer[] =>
-  uniqueBy(signers, samePublicKey);
+  uniqueBy(signers, (a, b) => a.publicKey === b.publicKey);
 
 /**
  * Creates a `Signer` that, when required to sign, does nothing.

--- a/packages/umi/src/Signer.ts
+++ b/packages/umi/src/Signer.ts
@@ -1,4 +1,4 @@
-import { PublicKey, samePublicKey } from './PublicKey';
+import { Pda, PublicKey, samePublicKey } from './PublicKey';
 import { Transaction } from './Transaction';
 import { uniqueBy } from './utils';
 
@@ -84,8 +84,8 @@ export const signAllTransactions = async (
  * Whether the provided value is a `Signer`.
  * @category Signers and PublicKeys
  */
-export const isSigner = (value: PublicKey | Signer): value is Signer =>
-  'publicKey' in value;
+export const isSigner = (value: PublicKey | Pda | Signer): value is Signer =>
+  typeof value === 'object' && 'publicKey' in value && 'signMessage' in value;
 
 /**
  * Deduplicates the provided signers by public key.

--- a/packages/umi/src/Transaction.ts
+++ b/packages/umi/src/Transaction.ts
@@ -1,6 +1,6 @@
 import { Amount, SolAmount } from './Amount';
 import type { Instruction } from './Instruction';
-import { PublicKey, samePublicKey } from './PublicKey';
+import { PublicKey } from './PublicKey';
 import type { Commitment } from './RpcInterface';
 
 /**
@@ -236,8 +236,8 @@ export const addTransactionSignature = (
 ): Transaction => {
   const maxSigners = transaction.message.header.numRequiredSignatures;
   const signerPublicKeys = transaction.message.accounts.slice(0, maxSigners);
-  const signerIndex = signerPublicKeys.findIndex((key) =>
-    samePublicKey(key, signerPublicKey)
+  const signerIndex = signerPublicKeys.findIndex(
+    (key) => key === signerPublicKey
   );
 
   if (signerIndex < 0) {

--- a/packages/umi/src/errors/AccountNotFoundError.ts
+++ b/packages/umi/src/errors/AccountNotFoundError.ts
@@ -1,4 +1,4 @@
-import { base58PublicKey, PublicKey } from '../PublicKey';
+import { PublicKey } from '../PublicKey';
 import { SdkError } from './SdkError';
 
 /** @category Errors */
@@ -10,9 +10,7 @@ export class AccountNotFoundError extends SdkError {
       accountType
         ? `The account of type [${accountType}] was not found`
         : 'No account was found'
-    } at the provided address [${base58PublicKey(publicKey)}].${
-      solution ? ` ${solution}` : ''
-    }`;
+    } at the provided address [${publicKey}].${solution ? ` ${solution}` : ''}`;
     super(message);
   }
 }

--- a/packages/umi/src/errors/InvalidPublicKeyError.ts
+++ b/packages/umi/src/errors/InvalidPublicKeyError.ts
@@ -1,0 +1,11 @@
+/** @category Errors */
+export class InvalidPublicKeyError extends Error {
+  readonly name: string = 'InvalidPublicKeyError';
+
+  readonly invalidPublicKey: unknown;
+
+  constructor(invalidPublicKey: unknown) {
+    super(`The provided public key is invalid: ${invalidPublicKey}`);
+    this.invalidPublicKey = invalidPublicKey;
+  }
+}

--- a/packages/umi/src/errors/InvalidPublicKeyError.ts
+++ b/packages/umi/src/errors/InvalidPublicKeyError.ts
@@ -4,8 +4,9 @@ export class InvalidPublicKeyError extends Error {
 
   readonly invalidPublicKey: unknown;
 
-  constructor(invalidPublicKey: unknown) {
-    super(`The provided public key is invalid: ${invalidPublicKey}`);
+  constructor(invalidPublicKey: unknown, reason?: string) {
+    reason = reason ? `. ${reason}` : '';
+    super(`The provided public key is invalid: ${invalidPublicKey}${reason}`);
     this.invalidPublicKey = invalidPublicKey;
   }
 }

--- a/packages/umi/src/errors/ProgramError.ts
+++ b/packages/umi/src/errors/ProgramError.ts
@@ -1,5 +1,4 @@
 import type { Program } from '../Program';
-import { base58PublicKey } from '../PublicKey';
 import { UmiError } from './UmiError';
 
 /** @category Errors */
@@ -18,12 +17,7 @@ export class ProgramError extends UmiError {
     program: Program,
     cause?: UnderlyingProgramError
   ) {
-    super(
-      message,
-      'program',
-      `${program.name} [${base58PublicKey(program.publicKey)}]`,
-      cause
-    );
+    super(message, 'program', `${program.name} [${program.publicKey}]`, cause);
     this.program = program;
     this.logs = cause?.logs;
     if (this.logs) {

--- a/packages/umi/src/errors/UnexpectedAccountError.ts
+++ b/packages/umi/src/errors/UnexpectedAccountError.ts
@@ -1,4 +1,4 @@
-import { base58PublicKey, PublicKey } from '../PublicKey';
+import { PublicKey } from '../PublicKey';
 import { SdkError } from './SdkError';
 
 /** @category Errors */
@@ -7,7 +7,7 @@ export class UnexpectedAccountError extends SdkError {
 
   constructor(publicKey: PublicKey, expectedType: string, cause?: Error) {
     const message =
-      `The account at the provided address [${base58PublicKey(publicKey)}] ` +
+      `The account at the provided address [${publicKey}] ` +
       `is not of the expected type [${expectedType}].`;
     super(message, cause);
   }

--- a/packages/umi/src/errors/index.ts
+++ b/packages/umi/src/errors/index.ts
@@ -2,6 +2,7 @@ export * from './AccountNotFoundError';
 export * from './AmountMismatchError';
 export * from './InterfaceImplementationMissingError';
 export * from './InvalidBaseStringError';
+export * from './InvalidPublicKeyError';
 export * from './ProgramError';
 export * from './SdkError';
 export * from './UmiError';

--- a/packages/umi/test/GpaBuilder.test.ts
+++ b/packages/umi/test/GpaBuilder.test.ts
@@ -5,6 +5,7 @@ import {
   defaultPublicKey,
   GpaBuilder,
   gpaBuilder,
+  publicKeyBytes,
   RpcAccount,
   Serializer,
 } from '../src';
@@ -58,7 +59,7 @@ test('it can add memcmp filters', (t) => {
 
   builder = getTestGpaBuilder().where(42, defaultPublicKey());
   t.deepEqual(builder.options.filters?.[0], {
-    memcmp: { offset: 42, bytes: defaultPublicKey().bytes },
+    memcmp: { offset: 42, bytes: publicKeyBytes(defaultPublicKey()) },
   });
 });
 

--- a/packages/umi/test/PublicKey.test.ts
+++ b/packages/umi/test/PublicKey.test.ts
@@ -2,17 +2,15 @@ import test from 'ava';
 import { createNoopSigner, publicKey } from '../src';
 
 test('it can create PublicKeys from base 58 strings', (t) => {
-  t.deepEqual(publicKey('11111111111111111111111111111111'), {
-    bytes: new Uint8Array(Array(32).fill(0)),
-  });
+  t.deepEqual(
+    publicKey('11111111111111111111111111111111'),
+    '11111111111111111111111111111111'
+  );
 
-  t.deepEqual(publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'), {
-    bytes: new Uint8Array([
-      48, 195, 33, 91, 254, 142, 96, 119, 69, 93, 155, 127, 231, 0, 98, 115,
-      193, 101, 97, 80, 204, 136, 168, 50, 218, 168, 254, 212, 56, 247, 237,
-      178,
-    ]),
-  });
+  t.deepEqual(
+    publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'),
+    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'
+  );
 });
 
 test('it can create PublicKeys from bytes', (t) => {
@@ -20,34 +18,29 @@ test('it can create PublicKeys from bytes', (t) => {
     48, 195, 33, 91, 254, 142, 96, 119, 69, 93, 155, 127, 231, 0, 98, 115, 193,
     101, 97, 80, 204, 136, 168, 50, 218, 168, 254, 212, 56, 247, 237, 178,
   ]);
-  const key = publicKey(bytes);
+  t.is(publicKey(bytes), '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
 
-  // The bytes are copied.
-  t.deepEqual(key, { bytes });
-  t.not(key.bytes, bytes);
+  t.is(
+    publicKey(new Uint8Array(Array(32).fill(0))),
+    '11111111111111111111111111111111'
+  );
 });
 
 test('it can create PublicKeys from other public keys', (t) => {
   const keyA = publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
   const keyB = publicKey(keyA);
-
-  // The bytes are copied.
-  t.deepEqual(keyB, keyA);
-  t.not(keyB, keyA);
+  t.is(keyB, keyA);
 });
 
 test('it can create PublicKeys from other public key wrappers like Signers', (t) => {
   const keyA = publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
   const signerA = createNoopSigner(keyA);
   const keyB = publicKey(signerA);
-
-  // The bytes are copied.
-  t.deepEqual(keyB, signerA.publicKey);
-  t.not(keyB, signerA.publicKey);
+  t.is(keyB, signerA.publicKey);
 });
 
 test('it fails to create PublicKeys if its length is not 32 bytes', (t) => {
-  const expectation = { message: 'Invalid public key' };
+  const expectation = { name: 'InvalidPublicKeyError' };
   t.throws(() => publicKey(''), expectation);
   t.throws(() => publicKey('1'), expectation);
   t.throws(() => publicKey('x'), expectation);
@@ -58,9 +51,6 @@ test('it fails to create PublicKeys if its length is not 32 bytes', (t) => {
   t.throws(() => publicKey(new Uint8Array([1])), expectation);
   t.throws(() => publicKey(new Uint8Array(Array(31).fill(42))), expectation);
   t.throws(() => publicKey(new Uint8Array(Array(33).fill(42))), expectation);
-  t.throws(() => publicKey({ bytes: new Uint8Array([42]) }), expectation);
-  t.throws(
-    () => publicKey({ publicKey: { bytes: new Uint8Array([42]) } }),
-    expectation
-  );
+  t.throws(() => publicKey({ publicKey: 'x' }), expectation);
+  t.throws(() => publicKey({ toBase58: () => 'x' }), expectation);
 });

--- a/packages/umi/test/PublicKey.test.ts
+++ b/packages/umi/test/PublicKey.test.ts
@@ -1,15 +1,15 @@
 import test from 'ava';
-import { createNoopSigner, publicKey } from '../src';
+import { PublicKey, createNoopSigner, publicKey } from '../src';
 
 test('it can create PublicKeys from base 58 strings', (t) => {
-  t.deepEqual(
+  t.is(
     publicKey('11111111111111111111111111111111'),
-    '11111111111111111111111111111111'
+    '11111111111111111111111111111111' as PublicKey
   );
 
-  t.deepEqual(
+  t.is(
     publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'),
-    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'
+    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9' as PublicKey
   );
 });
 
@@ -18,11 +18,14 @@ test('it can create PublicKeys from bytes', (t) => {
     48, 195, 33, 91, 254, 142, 96, 119, 69, 93, 155, 127, 231, 0, 98, 115, 193,
     101, 97, 80, 204, 136, 168, 50, 218, 168, 254, 212, 56, 247, 237, 178,
   ]);
-  t.is(publicKey(bytes), '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9');
+  t.is(
+    publicKey(bytes),
+    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9' as PublicKey
+  );
 
   t.is(
     publicKey(new Uint8Array(Array(32).fill(0))),
-    '11111111111111111111111111111111'
+    '11111111111111111111111111111111' as PublicKey
   );
 });
 

--- a/packages/umi/test/PublicKey.test.ts
+++ b/packages/umi/test/PublicKey.test.ts
@@ -4,12 +4,12 @@ import { PublicKey, createNoopSigner, publicKey } from '../src';
 test('it can create PublicKeys from base 58 strings', (t) => {
   t.is(
     publicKey('11111111111111111111111111111111'),
-    '11111111111111111111111111111111' as PublicKey
+    '11111111111111111111111111111111' as PublicKey<'11111111111111111111111111111111'>
   );
 
   t.is(
     publicKey('4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'),
-    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9' as PublicKey
+    '4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9' as PublicKey<'4HM9LW2rm3SR2ZdBiFK3D21ENmQWpqEJEhx1nfgcC3r9'>
   );
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5863,7 +5863,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001436
+      caniuse-lite: 1.0.30001502
       electron-to-chromium: 1.4.284
       node-releases: 2.0.6
       update-browserslist-db: 1.0.10(browserslist@4.21.4)
@@ -6005,8 +6005,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite@1.0.30001436:
-    resolution: {integrity: sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==}
+  /caniuse-lite@1.0.30001502:
+    resolution: {integrity: sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==}
     dev: true
 
   /capability@0.2.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@ava/typescript':
         specifier: ^3.0.1
         version: 3.0.1
+      '@solana/keys':
+        specifier: 2.0.0-experimental.7d8a778
+        version: 2.0.0-experimental.7d8a778
       ava:
         specifier: ^5.1.0
         version: 5.1.0(@ava/typescript@3.0.1)
@@ -4340,6 +4343,12 @@ packages:
     dependencies:
       buffer: 6.0.3
 
+  /@solana/keys@2.0.0-experimental.7d8a778:
+    resolution: {integrity: sha512-n0FAssDlT65RQtlYrtJfVKgz7EvzgWQAyMxMFq9j5Wrh59+PRnWpOAEK4CN+OUVaDHk0L57ehoRx4T2vHUGu0A==}
+    dependencies:
+      bs58: 5.0.0
+    dev: true
+
   /@solana/spl-token-registry@0.2.4574:
     resolution: {integrity: sha512-JzlfZmke8Rxug20VT/VpI2XsXlsqMlcORIUivF+Yucj7tFi7A0dXG7h+2UnD0WaZJw8BrUz2ABNkUnv89vbv1A==}
     engines: {node: '>=10'}
@@ -5643,6 +5652,10 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
+  /base-x@4.0.0:
+    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
+    dev: true
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -5860,6 +5873,12 @@ packages:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
       base-x: 3.0.9
+
+  /bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+    dependencies:
+      base-x: 4.0.0
+    dev: true
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,6 @@ importers:
       '@ava/typescript':
         specifier: ^3.0.1
         version: 3.0.1
-      '@solana/keys':
-        specifier: 2.0.0-experimental.7d8a778
-        version: 2.0.0-experimental.7d8a778
       ava:
         specifier: ^5.1.0
         version: 5.1.0(@ava/typescript@3.0.1)
@@ -4343,12 +4340,6 @@ packages:
     dependencies:
       buffer: 6.0.3
 
-  /@solana/keys@2.0.0-experimental.7d8a778:
-    resolution: {integrity: sha512-n0FAssDlT65RQtlYrtJfVKgz7EvzgWQAyMxMFq9j5Wrh59+PRnWpOAEK4CN+OUVaDHk0L57ehoRx4T2vHUGu0A==}
-    dependencies:
-      bs58: 5.0.0
-    dev: true
-
   /@solana/spl-token-registry@0.2.4574:
     resolution: {integrity: sha512-JzlfZmke8Rxug20VT/VpI2XsXlsqMlcORIUivF+Yucj7tFi7A0dXG7h+2UnD0WaZJw8BrUz2ABNkUnv89vbv1A==}
     engines: {node: '>=10'}
@@ -5652,10 +5643,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
-  /base-x@4.0.0:
-    resolution: {integrity: sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==}
-    dev: true
-
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -5873,12 +5860,6 @@ packages:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
     dependencies:
       base-x: 3.0.9
-
-  /bs58@5.0.0:
-    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
-    dependencies:
-      base-x: 4.0.0
-    dev: true
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}


### PR DESCRIPTION
### What?
This PR updates the definition of a `PublicKey` in Umi from an object with a `bytes` attribute to a simple base58 encoded string.

### Why?
- It makes the end-user API simpler.
- It makes public keys "pure" values that can easily be shared and logged.
- It makes Umi's API closer to the new web3.js library (See [the `@solana/keys` package](https://github.com/solana-labs/solana-web3.js/blob/6524b01189cd4917da62fe78a33fef58bd692986/packages/keys/src/base58.ts)).

### How?
- `PublicKey` is now a `string` instead of a `{ bytes: Uint8Array }`.
- `Pda` is now a `[PublicKey, number]` since it can no longer be a super set of `PublicKey`. The Kinobi renderer will have to be updated accordingly to keep the same API for the end user.
- Both `PublicKey` and `Pda` use opaque types so that we can rely on them being valid public keys. I.e. they must go through some assertion process to be marked as that type. I initially wanted to use the same TypeScript `unique symbol` that `@solana/keys` uses but unfortunately that requires importing the whole library as a regular dependency just for a type (devDependency would not work for dependant libraries). Something to revisit later that won't be a breaking change.
- `publicKeyBytes` safely retrieves the bytes from a `PublicKey`
- `assertPublicKey` ensures the provided value is a valid base58 public key.
- `publicKey` still converts a bunch of `PublicKeyInput` into a `PublicKey` and assert the latter is a valid base58 public key. It now accepts an optional boolean parameter to bypass the assertion. However, when bypassing the assertion, TypeScript will expect a `SafePublicKeyInput` to be provided, i.e. the input should have already been asserted.
- A bunch of methods such as `base58PublicKey` and `samePublicKey` have been deprecated since we can now handle strings directly.
- All dependant interfaces and tests were updated to accommodate the new API.

### Next steps
- Update the JavaScript renderer in Kinobi (See [WIP branch](https://github.com/metaplex-foundation/kinobi/compare/main...loris/keys-as-strings)).