### PR TITLE
Enable RPC call with unresolved parameters

### DIFF
--- a/.changeset/sour-poems-flash.md
+++ b/.changeset/sour-poems-flash.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi-rpc-web3js': patch
+---
+
+Enable RPC call with unresolved parameters

--- a/packages/umi-rpc-web3js/rollup.config.js
+++ b/packages/umi-rpc-web3js/rollup.config.js
@@ -3,6 +3,7 @@ import pkg from './package.json';
 
 export default createConfigs({
   pkg,
+  additionalExternals: ['@metaplex-foundation/umi/serializers'],
   builds: [
     {
       dir: 'dist/esm',

--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -36,7 +36,6 @@ import {
   TransactionSignature,
   TransactionStatus,
   TransactionWithMeta,
-  base58,
   createAmount,
   dateTime,
   isZeroAmount,
@@ -48,6 +47,7 @@ import {
   fromWeb3JsPublicKey,
   toWeb3JsPublicKey,
 } from '@metaplex-foundation/umi-web3js-adapters';
+import { base58 } from '@metaplex-foundation/umi/serializers';
 import {
   AccountInfo as Web3JsAccountInfo,
   Connection as Web3JsConnection,
@@ -290,7 +290,6 @@ export function createWeb3JsRpc(
   ): Promise<Result> => {
     const client = (getConnection() as any)._rpcClient as RpcClient;
     const resolvedParams = resolveCallParams(
-      getConnection(),
       (params ? [...params] : []) as [...Params],
       options.commitment,
       options.extra
@@ -412,22 +411,14 @@ function parseConfirmStrategy(
 }
 
 function resolveCallParams<Params extends any[]>(
-  connection: Web3JsConnection,
   args: Params,
-  override?: Commitment,
+  commitment?: Commitment,
   extra?: object
 ): Params {
-  const commitment =
-    override || (connection.commitment as Commitment | undefined);
-  if (commitment || extra) {
-    let options: any = {};
-    if (commitment) {
-      options.commitment = commitment;
-    }
-    if (extra) {
-      options = { ...options, ...extra };
-    }
-    args.push(options);
-  }
+  if (!commitment && !extra) return args;
+  let options: any = {};
+  if (commitment) options.commitment = commitment;
+  if (extra) options = { ...options, ...extra };
+  args.push(options);
   return args;
 }


### PR DESCRIPTION
The Web3.js RPC implementation was always adding an object parameter containing the connection's commitment even when no explicit commitment or extra option was provided.