### PR TITLE
Don't copy array when deserializing buffer to base64

### DIFF
--- a/packages/umi-serializers-encodings/src/base64.ts
+++ b/packages/umi-serializers-encodings/src/base64.ts
@@ -22,7 +22,7 @@ export const base64: Serializer<string> = {
   },
   deserialize(buffer, offset = 0) {
     const slice = buffer.slice(offset);
-    const value = btoa(String.fromCharCode.apply(null, [...slice]));
+    const value = btoa(String.fromCharCode(...slice));
     return [value, buffer.length];
   },
 };


### PR DESCRIPTION
This syntax will prevent the copy _and_ make TypeScript happy.