### PR TITLE
Require NFT Storage Token

### DIFF
--- a/.changeset/clean-flowers-sin.md
+++ b/.changeset/clean-flowers-sin.md
@@ -1,0 +1,7 @@
+---
+"@metaplex-foundation/umi-uploader-nft-storage": patch
+---
+
+Require NFT Storage Token
+
+Whilst this is technically a breaking change, NFT Storage themselves removed the ability to use their API without a token and so the breaking change would happen regardless of this upgrade. Therefore, a patch upgrade was selected.

--- a/packages/umi-uploader-nft-storage/src/createNftStorageUploader.ts
+++ b/packages/umi-uploader-nft-storage/src/createNftStorageUploader.ts
@@ -25,7 +25,7 @@ import {
 
 export type NftStorageUploaderOptions = {
   payer?: Signer;
-  token?: string;
+  token: string;
   endpoint?: URL;
   gatewayHost?: string;
   batchSize?: number;
@@ -34,7 +34,7 @@ export type NftStorageUploaderOptions = {
 
 export function createNftStorageUploader(
   context: Pick<Context, 'rpc' | 'payer'>,
-  options: NftStorageUploaderOptions = {}
+  options: NftStorageUploaderOptions = { token: '' }
 ): UploaderInterface & {
   client: () => Promise<NFTStorage | NFTStorageMetaplexor>;
 } {
@@ -44,6 +44,9 @@ export function createNftStorageUploader(
   const { gatewayHost } = options;
   const batchSize = options.batchSize ?? 50;
   const useGatewayUrls = options.useGatewayUrls ?? true;
+  if (!token) {
+    throw new Error('NFT Storage token is required');
+  }
 
   const getClient = async (): Promise<NFTStorage | NFTStorageMetaplexor> => {
     if (token) {

--- a/packages/umi-uploader-nft-storage/test/NftStorageUploader.test.ts
+++ b/packages/umi-uploader-nft-storage/test/NftStorageUploader.test.ts
@@ -29,6 +29,8 @@ const getContext = (options?: NftStorageUploaderOptions): Context =>
       umi.use(nftStorageUploader(options));
     },
   });
+// Use a dummy token since the tests are skipped currently.
+const token = 'dummy';
 
 test.skip('it can upload one file', async (t) => {
   // Given a Context using NFT.Storage.
@@ -50,7 +52,7 @@ test.skip('it can upload one file', async (t) => {
 
 test.skip('it can upload one file without a Gateway URL', async (t) => {
   // Given a Context using NFT.Storage without Gateway URLs.
-  const context = getContext({ useGatewayUrls: false });
+  const context = getContext({ token, useGatewayUrls: false });
 
   // When we upload some asset.
   const [uri] = await context.uploader.upload([
@@ -64,7 +66,7 @@ test.skip('it can upload one file without a Gateway URL', async (t) => {
 
 test.skip('it can upload multiple files in batch', async (t) => {
   // Given a Context using NFT.Storage with a batch size of 1.
-  const context = getContext({ batchSize: 1 });
+  const context = getContext({ token, batchSize: 1 });
 
   // When we upload two assets.
   const uris = await context.uploader.upload([


### PR DESCRIPTION
NFT.storage now requires a token to be supplied.

With this implementation the old implementation that did not use a token is skipped, not deleted.