### PR TITLE
Skip Uint8Arrays on unwrapOptionRecursively

### DIFF
--- a/.changeset/rich-otters-rhyme.md
+++ b/.changeset/rich-otters-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi-options': patch
+---
+
+Skip Uint8Arrays on unwrapOptionRecursively

--- a/packages/umi-options/src/unwrapOptionRecursively.ts
+++ b/packages/umi-options/src/unwrapOptionRecursively.ts
@@ -50,8 +50,11 @@ export function unwrapOptionRecursively<T, U = null>(
   input: T,
   fallback?: () => U
 ): UnwrappedOption<T, U> {
-  // Because null passes `typeof input === 'object'`.
-  if (!input) return input as UnwrappedOption<T, U>;
+  // Types to bypass.
+  if (!input || ArrayBuffer.isView(input)) {
+    return input as UnwrappedOption<T, U>;
+  }
+
   const next = <X>(x: X) =>
     (fallback
       ? unwrapOptionRecursively(x, fallback)

--- a/packages/umi-options/test/unwrapOptionRecursively.test.ts
+++ b/packages/umi-options/test/unwrapOptionRecursively.test.ts
@@ -24,6 +24,12 @@ test('it can unwrap options recursively', (t) => {
   t.is(unwrapOptionRecursively(null), null);
   t.is(unwrapOptionRecursively(undefined), undefined);
 
+  // TypedArrays.
+  t.deepEqual(
+    unwrapOptionRecursively(new Uint8Array([1, 2, 3])),
+    new Uint8Array([1, 2, 3])
+  );
+
   // Functions.
   const fn = () => 42;
   t.is(unwrapOptionRecursively(fn), fn);


### PR DESCRIPTION
### Problem

Using `unwrapOptionRecursively` on an object that contains nested `Uint8Array`s would convert them into plain object.

### Solution

Identify if the recursive unwrapped type is a `Uint8Array` and skip unwrapping when that's the case.