### PR TITLE
Create baseXReslice serializer and use it for base64

### DIFF
--- a/.changeset/twelve-months-scream.md
+++ b/.changeset/twelve-months-scream.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi-serializers-encodings': patch
+---
+
+Create baseXReslice serializer and use it for base64

--- a/packages/umi-serializers-encodings/src/base64.ts
+++ b/packages/umi-serializers-encodings/src/base64.ts
@@ -1,28 +1,18 @@
-import type { Serializer } from '@metaplex-foundation/umi-serializers-core';
-import { InvalidBaseStringError } from './errors';
+import {
+  mapSerializer,
+  type Serializer,
+} from '@metaplex-foundation/umi-serializers-core';
+import { baseXReslice } from './baseXReslice';
 
 /**
  * A string serializer that uses base64 encoding.
  * @category Serializers
  */
-export const base64: Serializer<string> = {
-  description: 'base64',
-  fixedSize: null,
-  maxSize: null,
-  serialize(value: string) {
-    try {
-      return new Uint8Array(
-        atob(value)
-          .split('')
-          .map((c) => c.charCodeAt(0))
-      );
-    } catch (e) {
-      throw new InvalidBaseStringError(value, 64, e as Error);
-    }
-  },
-  deserialize(buffer, offset = 0) {
-    const slice = buffer.slice(offset);
-    const value = btoa(String.fromCharCode.apply(null, [...slice]));
-    return [value, buffer.length];
-  },
-};
+export const base64: Serializer<string> = mapSerializer(
+  baseXReslice(
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',
+    6
+  ),
+  (value) => value.replace(/=/g, ''),
+  (value) => value.padEnd(Math.ceil(value.length / 4) * 4, '=')
+);

--- a/packages/umi-serializers-encodings/src/baseX.ts
+++ b/packages/umi-serializers-encodings/src/baseX.ts
@@ -2,8 +2,14 @@ import type { Serializer } from '@metaplex-foundation/umi-serializers-core';
 import { InvalidBaseStringError } from './errors';
 
 /**
- * A string serializer that uses a custom alphabet.
- * This can be used to create serializers for base58, base64, etc.
+ * A string serializer that requires a custom alphabet and uses
+ * the length of that alphabet as the base. It then divides
+ * the input by the base as many times as necessary to get
+ * the output. It also supports leading zeroes by using the
+ * first character of the alphabet as the zero character.
+ *
+ * This can be used to create serializers such as base10 or base58.
+ *
  * @category Serializers
  */
 export const baseX = (alphabet: string): Serializer<string> => {

--- a/packages/umi-serializers-encodings/src/baseXReslice.ts
+++ b/packages/umi-serializers-encodings/src/baseXReslice.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-bitwise */
+import type { Serializer } from '@metaplex-foundation/umi-serializers-core';
+import { InvalidBaseStringError } from './errors';
+
+/**
+ * A string serializer that reslices bytes into custom chunks
+ * of bits that are then mapped to a custom alphabet.
+ *
+ * This can be used to create serializers whose alphabet
+ * is a power of 2 such as base16 or base64.
+ *
+ * @category Serializers
+ */
+export const baseXReslice = (
+  alphabet: string,
+  bits: number
+): Serializer<string> => {
+  const base = alphabet.length;
+  const reslice = (
+    input: number[],
+    inputBits: number,
+    outputBits: number,
+    useRemainder: boolean
+  ): number[] => {
+    const output = [];
+    let accumulator = 0;
+    let bitsInAccumulator = 0;
+    const mask = (1 << outputBits) - 1;
+    for (const value of input) {
+      accumulator = (accumulator << inputBits) | value;
+      bitsInAccumulator += inputBits;
+      while (bitsInAccumulator >= outputBits) {
+        bitsInAccumulator -= outputBits;
+        output.push((accumulator >> bitsInAccumulator) & mask);
+      }
+    }
+    if (useRemainder && bitsInAccumulator > 0) {
+      output.push((accumulator << (outputBits - bitsInAccumulator)) & mask);
+    }
+    return output;
+  };
+
+  return {
+    description: `base${base}`,
+    fixedSize: null,
+    maxSize: null,
+    serialize(value: string): Uint8Array {
+      // Check if the value is valid.
+      if (!value.match(new RegExp(`^[${alphabet}]*$`))) {
+        throw new InvalidBaseStringError(value, base);
+      }
+      if (value === '') return new Uint8Array();
+      const charIndices = [...value].map((c) => alphabet.indexOf(c));
+      const bytes = reslice(charIndices, bits, 8, false);
+      return Uint8Array.from(bytes);
+    },
+    deserialize(buffer, offset = 0): [string, number] {
+      if (buffer.length === 0) return ['', 0];
+      const bytes = [...buffer.slice(offset)];
+      const charIndices = reslice(bytes, 8, bits, true);
+      return [charIndices.map((i) => alphabet[i]).join(''), buffer.length];
+    },
+  };
+};

--- a/packages/umi-serializers-encodings/src/index.ts
+++ b/packages/umi-serializers-encodings/src/index.ts
@@ -3,6 +3,7 @@ export * from './base16';
 export * from './base58';
 export * from './base64';
 export * from './baseX';
+export * from './baseXReslice';
 export * from './errors';
 export * from './nullCharacters';
 export * from './utf8';

--- a/packages/umi-serializers-encodings/test/base64.test.ts
+++ b/packages/umi-serializers-encodings/test/base64.test.ts
@@ -3,9 +3,11 @@ import { base16, base64 } from '../src';
 
 test('it can serialize base 64 strings', (t) => {
   t.deepEqual(base64.serialize(''), new Uint8Array([]));
+  t.deepEqual(base64.serialize('A'), new Uint8Array([]));
   t.deepEqual(base64.deserialize(new Uint8Array([])), ['', 0]);
 
   t.deepEqual(base64.serialize('AA'), new Uint8Array([0]));
+  t.deepEqual(base64.serialize('AA='), new Uint8Array([0]));
   t.deepEqual(base64.serialize('AA=='), new Uint8Array([0]));
   t.deepEqual(base64.deserialize(new Uint8Array([0])), ['AA==', 1]);
 
@@ -26,10 +28,6 @@ test('it can serialize base 64 strings', (t) => {
   t.throws(() => base64.serialize('INVALID_INPUT'), {
     message: (m) =>
       m.includes('Expected a string of base 64, got [INVALID_INPUT].'),
-  });
-
-  t.throws(() => base64.serialize('A'), {
-    message: (m) => m.includes('Expected a string of base 64, got [A].'),
   });
 
   const base64TokenData =


### PR DESCRIPTION
This PR fixes https://github.com/metaplex-foundation/umi/issues/78 by removing the use of `atob` and `btoa` to create a `base64` serializer as these methods are not available on every supported environment.

It does so by creating a new `baseXReslice` serializer factory that reslices the bits of a buffers before mapping them to a custom alphabet. This is as opposed to the `baseX` serializer which takes the base of the alphabet and divide the input as many times as required to get the output. The `baseXReslice` serializer can then be used to create a `base64` serializer. All we need to do is map it so it provides a `=` padding to ensure the encoded string is multiple of 4 characters.