### PR TITLE
fix: `umi.downloader.downloadJson` can return a string if `content-type` is not set on response

### DIFF
--- a/packages/umi-downloader-http/src/createHttpDownloader.ts
+++ b/packages/umi-downloader-http/src/createHttpDownloader.ts
@@ -33,7 +33,16 @@ export function createHttpDownloader(
     const response = await context.http.send<T>(
       request().get(uri).withAbortSignal(options.signal)
     );
-    return response.data;
+
+    let json = response.data;
+    if (typeof json === 'string')
+      try {
+        json = JSON.parse(response.body);
+      } catch {
+        console.warn(`could not parse response from ${uri} as json: ${json}`);
+      }
+
+    return json;
   };
 
   return { download, downloadJson };


### PR DESCRIPTION
The `downloadJson()` function should try to parse the response as json even if the `content-type` header is missing or not `application/json`.
Some providers like `nftstorage.link` do not set the `content-type` header for some reason, resulting in the response being a string.

This PR makes `downloadJson()` try to parse the response as a json instead of silently returning a string.