### PR TITLE
Add signer as remaining account

### DIFF
--- a/.changeset/hot-beers-talk.md
+++ b/.changeset/hot-beers-talk.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi': patch
+---
+
+Add signer as remaining account

--- a/packages/umi/src/Instruction.ts
+++ b/packages/umi/src/Instruction.ts
@@ -40,3 +40,15 @@ export type AccountMeta = {
   isSigner: boolean;
   isWritable: boolean;
 };
+
+/**
+ * Defines a signer account required by an instruction.
+ * It includes the signer and whether the signer account
+ * should be writable.
+ *
+ * @category Transactions
+ */
+export type SignerMeta = {
+  signer: Signer;
+  isWritable: boolean;
+};

--- a/packages/umi/test/TransactionBuilder.test.ts
+++ b/packages/umi/test/TransactionBuilder.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { publicKey, transactionBuilder } from '../src';
+import { createNoopSigner, publicKey, transactionBuilder } from '../src';
 import { createUmi, mockInstruction, transferSol } from './_setup';
 
 test.skip('it can get the size of the transaction to build', (t) => {
@@ -118,5 +118,83 @@ test('it can add remaining accounts to a specific instruction', (t) => {
 
   // And the first and last instructions still have 1 account meta.
   t.is(mappedBuilder.items[0].instruction.keys.length, 1);
+  t.is(mappedBuilder.items[2].instruction.keys.length, 1);
+});
+
+test('it can add signer accounts to a specific instruction', (t) => {
+  // Given a signer.
+  const signer = createNoopSigner(
+    publicKey('auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg')
+  );
+
+  // Given a transaction builder with three instructions.
+  const builder = transactionBuilder()
+    .add(mockInstruction())
+    .add(mockInstruction())
+    .add(mockInstruction());
+
+  // And given all instructions have only one account meta.
+  t.true(builder.items.every((ix) => ix.instruction.keys.length === 1));
+
+  // When we add signer accounts to the first instruction.
+  const mappedBuilder = builder.addRemainingAccounts(
+    [
+      {
+        signer,
+        isWritable: true,
+      },
+    ],
+    0
+  );
+
+  // Then the first instruction has 2 account metas.
+  t.is(mappedBuilder.items[0].instruction.keys.length, 2);
+
+  // And the second and last instructions still have 1 account meta.
+  t.is(mappedBuilder.items[1].instruction.keys.length, 1);
+  t.is(mappedBuilder.items[2].instruction.keys.length, 1);
+});
+
+test('it can add signer and remaining accounts to a specific instruction', (t) => {
+  // Given a signer.
+  const signer = createNoopSigner(
+    publicKey('auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg')
+  );
+
+  // Given a transaction builder with three instructions.
+  const builder = transactionBuilder()
+    .add(mockInstruction())
+    .add(mockInstruction())
+    .add(mockInstruction());
+
+  // And given all instructions have only one account meta.
+  t.true(builder.items.every((ix) => ix.instruction.keys.length === 1));
+
+  // When we add signer accounts to the first instruction.
+  const mappedBuilder = builder.addRemainingAccounts(
+    [
+      {
+        pubkey: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+        isSigner: false,
+        isWritable: false,
+      },
+      {
+        pubkey: publicKey('auth9SigNpDKz4sJJ1DfCTuZrZNSAgh9sFD3rboVmgg'),
+        isSigner: false,
+        isWritable: false,
+      },
+      {
+        signer,
+        isWritable: false,
+      },
+    ],
+    0
+  );
+
+  // Then the first instruction has 2 account metas.
+  t.is(mappedBuilder.items[0].instruction.keys.length, 4);
+
+  // And the second and last instructions still have 1 account meta.
+  t.is(mappedBuilder.items[1].instruction.keys.length, 1);
   t.is(mappedBuilder.items[2].instruction.keys.length, 1);
 });


### PR DESCRIPTION
This PR enables passing a `Signer` type when adding remaining accounts, which adds the `Signer` as an `AccountMeta` and a signer on the instruction.