### PR TITLE
rpc-web3js: Allow passing Connection class directly

### DIFF
--- a/.changeset/hip-wasps-sip.md
+++ b/.changeset/hip-wasps-sip.md
@@ -1,0 +1,7 @@
+---
+'@metaplex-foundation/umi-rpc-chunk-get-accounts': patch
+'@metaplex-foundation/umi-bundle-defaults': patch
+'@metaplex-foundation/umi-rpc-web3js': patch
+---
+
+Allow instancing umi/RPCInterface with Connection class or RPC url

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -4,12 +4,18 @@ Contacting the Solana blockchain via an RPC is an important part of any decentra
 
 ## Configuring the RPC's endpoint
 
-When creating a new Umi instance via the default bundle, you must pass the RPC's endpoint as the first argument. Going forward, this it the endpoint that will be used every time you call a method on the RPC interface.
+When creating a new Umi instance via the default bundle, you must pass the RPC's endpoint or an instance of `@solana/web3.js`'s `Connection` class as the first argument. Going forward, this is the endpoint or `Connection` that will be used every time you call a method on the RPC interface.
 
 ```ts
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
 
 const umi = createUmi("https://api.mainnet-beta.solana.com");
+```
+```ts
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { Connection } from '@solana/web3.js';
+
+const umi = createUmi(new Connection("https://api.mainnet-beta.solana.com"));
 ```
 
 Alternatively, you may set or update the RPC implementation explicitly by the using the plugin they provide. For instance, the `web3JsRpc` plugin will set the RPC implementation to use the `@solana/web3.js` library.
@@ -18,6 +24,12 @@ Alternatively, you may set or update the RPC implementation explicitly by the us
 import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
 
 umi.use(web3JsRpc("https://api.mainnet-beta.solana.com"));
+```
+```ts
+import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
+import { Connection } from '@solana/web3.js';
+
+umi.use(web3JsRpc(new Connection("https://api.mainnet-beta.solana.com")));
 ```
 
 ## Getting the RPC's endpoint and cluster

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -8,13 +8,12 @@ When creating a new Umi instance via the default bundle, you must pass the RPC's
 
 ```ts
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
-
-const umi = createUmi("https://api.mainnet-beta.solana.com");
-```
-```ts
-import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
 import { Connection } from '@solana/web3.js';
 
+// Pass in your RPC endpoint.
+const umi = createUmi("https://api.mainnet-beta.solana.com");
+
+// Or an explicit Connection instance from web3.js.
 const umi = createUmi(new Connection("https://api.mainnet-beta.solana.com"));
 ```
 
@@ -22,13 +21,9 @@ Alternatively, you may set or update the RPC implementation explicitly by the us
 
 ```ts
 import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
-
-umi.use(web3JsRpc("https://api.mainnet-beta.solana.com"));
-```
-```ts
-import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
 import { Connection } from '@solana/web3.js';
 
+umi.use(web3JsRpc("https://api.mainnet-beta.solana.com"));
 umi.use(web3JsRpc(new Connection("https://api.mainnet-beta.solana.com")));
 ```
 

--- a/packages/umi-bundle-defaults/src/index.ts
+++ b/packages/umi-bundle-defaults/src/index.ts
@@ -1,10 +1,26 @@
 import { Umi, createUmi as baseCreateUmi } from '@metaplex-foundation/umi';
+import type { ChunkGetAccountsRpcOptions } from '@metaplex-foundation/umi-rpc-chunk-get-accounts';
 import type { Web3JsRpcOptions } from '@metaplex-foundation/umi-rpc-web3js';
+import type { Connection as Web3JsConnection } from '@solana/web3.js';
 import { defaultPlugins } from './plugin';
 
-export const createUmi = (
+export function createUmi(
   endpoint: string,
-  rpcOptions?: Web3JsRpcOptions
-): Umi => baseCreateUmi().use(defaultPlugins(endpoint, rpcOptions));
+  rpcOptions?: Web3JsRpcOptions & ChunkGetAccountsRpcOptions
+): Umi;
+export function createUmi(
+  connection: Web3JsConnection,
+  rpcOptions?: ChunkGetAccountsRpcOptions
+): Umi;
+export function createUmi(
+  endpointOrConnection: string | Web3JsConnection,
+  rpcOptions?: Web3JsRpcOptions & ChunkGetAccountsRpcOptions
+): Umi {
+  return baseCreateUmi().use(
+    typeof endpointOrConnection === 'string'
+      ? defaultPlugins(endpointOrConnection, rpcOptions)
+      : defaultPlugins(endpointOrConnection, rpcOptions)
+  );
+}
 
 export * from './plugin';

--- a/packages/umi-bundle-defaults/src/plugin.ts
+++ b/packages/umi-bundle-defaults/src/plugin.ts
@@ -7,22 +7,40 @@ import {
   web3JsRpc,
   Web3JsRpcOptions,
 } from '@metaplex-foundation/umi-rpc-web3js';
-import { chunkGetAccountsRpc } from '@metaplex-foundation/umi-rpc-chunk-get-accounts';
+import {
+  chunkGetAccountsRpc,
+  ChunkGetAccountsRpcOptions,
+} from '@metaplex-foundation/umi-rpc-chunk-get-accounts';
 import { dataViewSerializer } from '@metaplex-foundation/umi-serializer-data-view';
 import { web3JsTransactionFactory } from '@metaplex-foundation/umi-transaction-factory-web3js';
+import type { Connection as Web3JsConnection } from '@solana/web3.js';
 
-export const defaultPlugins = (
+export function defaultPlugins(
   endpoint: string,
-  rpcOptions?: Web3JsRpcOptions & { getAccountsChunkSize?: number }
-): UmiPlugin => ({
-  install(umi) {
-    umi.use(dataViewSerializer());
-    umi.use(defaultProgramRepository());
-    umi.use(fetchHttp());
-    umi.use(httpDownloader());
-    umi.use(web3JsEddsa());
-    umi.use(web3JsRpc(endpoint, rpcOptions));
-    umi.use(chunkGetAccountsRpc(rpcOptions?.getAccountsChunkSize));
-    umi.use(web3JsTransactionFactory());
-  },
-});
+  rpcOptions?: Web3JsRpcOptions & ChunkGetAccountsRpcOptions
+): UmiPlugin;
+export function defaultPlugins(
+  connection: Web3JsConnection,
+  rpcOptions?: ChunkGetAccountsRpcOptions
+): UmiPlugin;
+export function defaultPlugins(
+  endpointOrConnection: string | Web3JsConnection,
+  rpcOptions?: Web3JsRpcOptions & ChunkGetAccountsRpcOptions
+): UmiPlugin {
+  return {
+    install(umi) {
+      umi.use(dataViewSerializer());
+      umi.use(defaultProgramRepository());
+      umi.use(fetchHttp());
+      umi.use(httpDownloader());
+      umi.use(web3JsEddsa());
+      umi.use(
+        typeof endpointOrConnection === 'string'
+          ? web3JsRpc(endpointOrConnection, rpcOptions)
+          : web3JsRpc(endpointOrConnection)
+      );
+      umi.use(chunkGetAccountsRpc(rpcOptions?.getAccountsChunkSize));
+      umi.use(web3JsTransactionFactory());
+    },
+  };
+}

--- a/packages/umi-rpc-chunk-get-accounts/src/createChunkGetAccountsRpc.ts
+++ b/packages/umi-rpc-chunk-get-accounts/src/createChunkGetAccountsRpc.ts
@@ -1,5 +1,9 @@
 import { RpcInterface, chunk } from '@metaplex-foundation/umi';
 
+export interface ChunkGetAccountsRpcOptions {
+  getAccountsChunkSize?: number;
+}
+
 export const createChunkGetAccountsRpc = (
   rpc: RpcInterface,
   chunkSize = 100

--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -66,16 +66,30 @@ export function createWeb3JsRpc(
   context: Pick<Context, 'programs' | 'transactions'>,
   endpoint: string,
   rpcOptions?: Web3JsRpcOptions
+): RpcInterface & { connection: Web3JsConnection };
+export function createWeb3JsRpc(
+  context: Pick<Context, 'programs' | 'transactions'>,
+  connection: Web3JsConnection
+): RpcInterface & { connection: Web3JsConnection };
+export function createWeb3JsRpc(
+  context: Pick<Context, 'programs' | 'transactions'>,
+  endpointOrConnection: string | Web3JsConnection,
+  rpcOptions?: Web3JsRpcOptions
 ): RpcInterface & { connection: Web3JsConnection } {
-  const cluster = resolveClusterFromEndpoint(endpoint);
-
   let connection: Web3JsConnection | null = null;
   const getConnection = () => {
-    if (!connection) {
-      connection = new Web3JsConnection(endpoint, rpcOptions);
+    if (connection) {
+      return connection;
+    }
+    if (typeof endpointOrConnection === 'string') {
+      connection = new Web3JsConnection(endpointOrConnection, rpcOptions);
+    } else {
+      connection = endpointOrConnection;
     }
     return connection;
   };
+
+  const cluster = resolveClusterFromEndpoint(getConnection().rpcEndpoint);
 
   const getAccount = async (
     publicKey: PublicKey,

--- a/packages/umi-rpc-web3js/src/plugin.ts
+++ b/packages/umi-rpc-web3js/src/plugin.ts
@@ -1,11 +1,22 @@
 import { UmiPlugin } from '@metaplex-foundation/umi';
+import { Connection as Web3JsConnection } from '@solana/web3.js';
 import { createWeb3JsRpc, Web3JsRpcOptions } from './createWeb3JsRpc';
 
-export const web3JsRpc = (
+export function web3JsRpc(
   endpoint: string,
   rpcOptions?: Web3JsRpcOptions
-): UmiPlugin => ({
-  install(umi) {
-    umi.rpc = createWeb3JsRpc(umi, endpoint, rpcOptions);
-  },
-});
+): UmiPlugin;
+export function web3JsRpc(connection: Web3JsConnection): UmiPlugin;
+export function web3JsRpc(
+  endpointOrConnection: string | Web3JsConnection,
+  rpcOptions?: Web3JsRpcOptions
+): UmiPlugin {
+  return {
+    install(umi) {
+      umi.rpc =
+        typeof endpointOrConnection === 'string'
+          ? createWeb3JsRpc(umi, endpointOrConnection, rpcOptions)
+          : createWeb3JsRpc(umi, endpointOrConnection);
+    },
+  };
+}

--- a/packages/umi-rpc-web3js/src/plugin.ts
+++ b/packages/umi-rpc-web3js/src/plugin.ts
@@ -1,5 +1,5 @@
 import { UmiPlugin } from '@metaplex-foundation/umi';
-import { Connection as Web3JsConnection } from '@solana/web3.js';
+import type { Connection as Web3JsConnection } from '@solana/web3.js';
 import { createWeb3JsRpc, Web3JsRpcOptions } from './createWeb3JsRpc';
 
 export function web3JsRpc(


### PR DESCRIPTION
we would like to be able to pass our own class, which itself implements `Connection`, rather than only being able to pass a single rpc endpoint or having to reimplement our custom `Connection` logic for the `RpcInterface` interface

- allow passing `Connection` to `createUmi` from `umi-bundle-defaults`
- allow passing `getAccountsChunkSize` to `createUmi` from `umi-bundle-defaults`
- allow passing `Connection` to `createWeb3JsRpc` and `web3JsRpc` from `umi-rpc-web3js`