### PR TITLE
Fix builders order on append

### DIFF
--- a/.changeset/thirty-pants-warn.md
+++ b/.changeset/thirty-pants-warn.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi': patch
+---
+
+Fix builders order on append

--- a/packages/umi/src/TransactionBuilderGroup.ts
+++ b/packages/umi/src/TransactionBuilderGroup.ts
@@ -42,7 +42,7 @@ export class TransactionBuilderGroup {
   ): TransactionBuilderGroup {
     const newBuilders = Array.isArray(builder) ? builder : [builder];
     return new TransactionBuilderGroup(
-      [...newBuilders, ...this.builders],
+      [...this.builders, ...newBuilders],
       this.options
     );
   }


### PR DESCRIPTION
This PR fixes the order of builders on the `append` method of a `TransactionBuilderGroup` – currently it has the same behaviour as `prepend`.