### PR TITLE
Add umi-uploader-cascade plugin

### DIFF
--- a/packages/umi-uploader-cascade/CHANGELOG.md
+++ b/packages/umi-uploader-cascade/CHANGELOG.md
@@ -1,0 +1,300 @@
+# @metaplex-foundation/umi-uploader-nft-storage
+
+## 0.9.1
+
+### Patch Changes
+
+- [#112](https://github.com/metaplex-foundation/umi/pull/112) [`7c03bd1`](https://github.com/metaplex-foundation/umi/commit/7c03bd1841e14f9352d0c166e5d5e305a543c77a) Thanks [@KishiTheMechanic](https://github.com/KishiTheMechanic)! - Update nft.storage version to fix type URLSearchParams error
+
+- Updated dependencies [[`c450559`](https://github.com/metaplex-foundation/umi/commit/c4505599778ca53695b9762f523fd39f813a0ec9), [`7c03bd1`](https://github.com/metaplex-foundation/umi/commit/7c03bd1841e14f9352d0c166e5d5e305a543c77a)]:
+  - @metaplex-foundation/umi@0.9.1
+
+## 0.9.0
+
+### Patch Changes
+
+- Updated dependencies [[`703bace`](https://github.com/metaplex-foundation/umi/commit/703baceb19155a53923eb63b99fdb08e7bf7cce8)]:
+  - @metaplex-foundation/umi@0.9.0
+
+## 0.8.10
+
+### Patch Changes
+
+- Updated dependencies [[`4b4061a`](https://github.com/metaplex-foundation/umi/commit/4b4061a10ba615585aff9c2c4256137cc39fa68c)]:
+  - @metaplex-foundation/umi@0.8.10
+
+## 0.8.9
+
+### Patch Changes
+
+- [#86](https://github.com/metaplex-foundation/umi/pull/86) [`05e4f9f`](https://github.com/metaplex-foundation/umi/commit/05e4f9ffa4e73d9db8442b26cd32577dc32075c2) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Add types file to package.json exports
+
+- Updated dependencies [[`05e4f9f`](https://github.com/metaplex-foundation/umi/commit/05e4f9ffa4e73d9db8442b26cd32577dc32075c2)]:
+  - @metaplex-foundation/umi@0.8.9
+
+## 0.8.8
+
+### Patch Changes
+
+- [#80](https://github.com/metaplex-foundation/umi/pull/80) [`e58e353`](https://github.com/metaplex-foundation/umi/commit/e58e353f5d76d668d406ba9b9b5ee285db9eef95) Thanks [@MarkSackerberg](https://github.com/MarkSackerberg)! - Require NFT Storage Token
+
+  Whilst this is technically a breaking change, NFT Storage themselves removed the ability to use their API without a token and so the breaking change would happen regardless of this upgrade. Therefore, a patch upgrade was selected.
+
+- Updated dependencies []:
+  - @metaplex-foundation/umi@0.8.8
+
+## 0.8.7
+
+### Patch Changes
+
+- Updated dependencies [[`7b675bc`](https://github.com/metaplex-foundation/umi/commit/7b675bc08b9442148282f35219cf8163545f160d)]:
+  - @metaplex-foundation/umi@0.8.7
+
+## 0.8.6
+
+### Patch Changes
+
+- Updated dependencies [[`aba3519`](https://github.com/metaplex-foundation/umi/commit/aba35199c9f481b5aaf81f812ce945e07796a6aa)]:
+  - @metaplex-foundation/umi@0.8.6
+
+## 0.8.5
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @metaplex-foundation/umi@0.8.5
+
+## 0.8.4
+
+### Patch Changes
+
+- Updated dependencies [[`d1e0c09`](https://github.com/metaplex-foundation/umi/commit/d1e0c09550bf07fe8bc0865f9732f025c3d8dafe), [`99bf51d`](https://github.com/metaplex-foundation/umi/commit/99bf51d6f58d7fe5b73d7678478ac8463c87d857)]:
+  - @metaplex-foundation/umi@0.8.4
+
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies [[`4accd34`](https://github.com/metaplex-foundation/umi/commit/4accd34f0a70d360321c42f395a2ad45cbadca16), [`4342375`](https://github.com/metaplex-foundation/umi/commit/43423750c9b351446b868ede57ecb634cebde42a), [`4342375`](https://github.com/metaplex-foundation/umi/commit/43423750c9b351446b868ede57ecb634cebde42a)]:
+  - @metaplex-foundation/umi@0.8.2
+
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [[`bc11e6e`](https://github.com/metaplex-foundation/umi/commit/bc11e6e6f964594c75d04f78ef6c86a87aae6749)]:
+  - @metaplex-foundation/umi@0.8.1
+
+## 0.8.0
+
+### Minor Changes
+
+- [#62](https://github.com/metaplex-foundation/umi/pull/62) [`15392cd`](https://github.com/metaplex-foundation/umi/commit/15392cd9a98d55750be09268c8ee93611d159e03) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Use PublicKeys as base58 strings. See `@metaplex-foundation/umi` changelog for more details.
+
+### Patch Changes
+
+- Updated dependencies [[`15392cd`](https://github.com/metaplex-foundation/umi/commit/15392cd9a98d55750be09268c8ee93611d159e03)]:
+  - @metaplex-foundation/umi@0.8.0
+
+## 0.7.14
+
+### Patch Changes
+
+- Updated dependencies [[`f530089`](https://github.com/metaplex-foundation/umi/commit/f5300891d0bad4b13431a11d87bfa35b6881ae56)]:
+  - @metaplex-foundation/umi@0.7.14
+
+## 0.7.13
+
+### Patch Changes
+
+- Updated dependencies [[`6a33ea3`](https://github.com/metaplex-foundation/umi/commit/6a33ea32937f37cb34114582f2c365ac21c6d8e5), [`6a33ea3`](https://github.com/metaplex-foundation/umi/commit/6a33ea32937f37cb34114582f2c365ac21c6d8e5)]:
+  - @metaplex-foundation/umi@0.7.13
+
+## 0.7.11
+
+### Patch Changes
+
+- Updated dependencies [[`38c98dc`](https://github.com/metaplex-foundation/umi/commit/38c98dcc7c61ce212198381765b80fa695c51fa7)]:
+  - @metaplex-foundation/umi@0.7.11
+
+## 0.7.10
+
+### Patch Changes
+
+- Updated dependencies [[`c1c1da6`](https://github.com/metaplex-foundation/umi/commit/c1c1da6bbed341492c3d81a4edc7aebb43471345), [`1139bcf`](https://github.com/metaplex-foundation/umi/commit/1139bcfedc541d6b89df2d61b10c4fdc169c4eee)]:
+  - @metaplex-foundation/umi@0.7.10
+
+## 0.7.7
+
+### Patch Changes
+
+- Updated dependencies [[`bf9b550`](https://github.com/metaplex-foundation/umi/commit/bf9b550ae945f3963f2c96361b7d7ab38921c6a7)]:
+  - @metaplex-foundation/umi@0.7.7
+
+## 0.7.6
+
+### Patch Changes
+
+- Updated dependencies [[`5b275d5`](https://github.com/metaplex-foundation/umi/commit/5b275d53680d66fcd77b1b09a30bf101036e22b3)]:
+  - @metaplex-foundation/umi@0.7.6
+
+## 0.7.5
+
+### Patch Changes
+
+- Updated dependencies [[`670e7d4`](https://github.com/metaplex-foundation/umi/commit/670e7d4ba00e41802226ee7c722a116ef141891f)]:
+  - @metaplex-foundation/umi@0.7.5
+
+## 0.7.4
+
+### Patch Changes
+
+- Updated dependencies [[`3718fae`](https://github.com/metaplex-foundation/umi/commit/3718faeafc28400313aa93f8e4db3945218ffb0b), [`00cb767`](https://github.com/metaplex-foundation/umi/commit/00cb7671976a63670bd71b70a06d5452b0761f62), [`f56fc59`](https://github.com/metaplex-foundation/umi/commit/f56fc59eee0deebf347e22a097c19aca1332a52a)]:
+  - @metaplex-foundation/umi@0.7.4
+
+## 0.7.2
+
+### Patch Changes
+
+- Updated dependencies [[`2756a69`](https://github.com/metaplex-foundation/umi/commit/2756a693fb1d5d1a90608744ca73165b663cc729)]:
+  - @metaplex-foundation/umi@0.7.2
+
+## 0.7.0
+
+### Minor Changes
+
+- [#34](https://github.com/metaplex-foundation/umi/pull/34) [`a963320`](https://github.com/metaplex-foundation/umi/commit/a9633202645a23b19c00ec973e93f5e5fda0776d) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Use functions instead of classes to implement interfaces
+
+### Patch Changes
+
+- Updated dependencies [[`a963320`](https://github.com/metaplex-foundation/umi/commit/a9633202645a23b19c00ec973e93f5e5fda0776d)]:
+  - @metaplex-foundation/umi@0.7.0
+
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [[`b1e898f`](https://github.com/metaplex-foundation/umi/commit/b1e898fb8f78eb3b7acedd6b77dcdfd161164b00)]:
+  - @metaplex-foundation/umi@0.6.0
+
+## 0.5.3
+
+### Patch Changes
+
+- Updated dependencies [[`c20d154`](https://github.com/metaplex-foundation/umi/commit/c20d15448537a93d7fe7a5f4765e0d3880ccc8cf), [`13acda9`](https://github.com/metaplex-foundation/umi/commit/13acda9d8c968716289e47b3e19b888f8ba11857)]:
+  - @metaplex-foundation/umi@0.5.3
+
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [[`3db36d1`](https://github.com/metaplex-foundation/umi/commit/3db36d13e281a171f407e9652e2404d54c2971bd)]:
+  - @metaplex-foundation/umi@0.5.2
+
+## 0.5.1
+
+### Patch Changes
+
+- [#24](https://github.com/metaplex-foundation/umi/pull/24) [`27276f4`](https://github.com/metaplex-foundation/umi/commit/27276f4ab5865bd55a5682990c5e48aa2d9b10cd) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Rename umi, umi-core and umi-test
+
+- Updated dependencies [[`27276f4`](https://github.com/metaplex-foundation/umi/commit/27276f4ab5865bd55a5682990c5e48aa2d9b10cd)]:
+  - @metaplex-foundation/umi@0.5.1
+
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [[`807b469`](https://github.com/metaplex-foundation/umi/commit/807b4691ed843f6a4247317362d71b6457ad291d)]:
+  - @metaplex-foundation/umi-core@0.4.1
+
+## 0.4.0
+
+### Patch Changes
+
+- Updated dependencies [[`d6ae534`](https://github.com/metaplex-foundation/umi/commit/d6ae5345ef4b8b8abca1cef04fd64e95f517e656), [`9f86429`](https://github.com/metaplex-foundation/umi/commit/9f8642945f000d84b07005bebe479be9a562db87), [`8d09519`](https://github.com/metaplex-foundation/umi/commit/8d0951983756a8c147ac3f4f95bb7cfc86294aa4)]:
+  - @metaplex-foundation/umi-core@0.4.0
+
+## 0.3.4
+
+### Patch Changes
+
+- Updated dependencies [[`c93f1c4`](https://github.com/metaplex-foundation/umi/commit/c93f1c487d347fa27163d29a8caefd1d035e9052)]:
+  - @metaplex-foundation/umi-core@0.3.4
+
+## 0.3.3
+
+### Patch Changes
+
+- Updated dependencies [[`422dc73`](https://github.com/metaplex-foundation/umi/commit/422dc73b5a5d84e89665ef69972a90cc947a20e5)]:
+  - @metaplex-foundation/umi-core@0.3.3
+
+## 0.3.2
+
+### Patch Changes
+
+- Updated dependencies [[`66a7d91`](https://github.com/metaplex-foundation/umi/commit/66a7d919146ee348739438f7b0e33cc746d5d1ba)]:
+  - @metaplex-foundation/umi-core@0.3.2
+
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies [[`e566c1b`](https://github.com/metaplex-foundation/umi/commit/e566c1ba7232e1020234a750ec83607d50f60c56), [`acdc77a`](https://github.com/metaplex-foundation/umi/commit/acdc77af0f6c6e231b42b22e116497908043c57c)]:
+  - @metaplex-foundation/umi-core@0.3.1
+
+## 0.3.0
+
+### Patch Changes
+
+- Updated dependencies [[`95d56e9`](https://github.com/metaplex-foundation/umi/commit/95d56e969b3da53e7b60758db4c530d206765697)]:
+  - @metaplex-foundation/umi-core@0.3.0
+
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies [[`697bddd`](https://github.com/metaplex-foundation/umi/commit/697bddd6cdd520bd1f9190eb9827c3f351512145)]:
+  - @metaplex-foundation/umi-core@0.2.3
+
+## 0.2.2
+
+### Patch Changes
+
+- Updated dependencies [[`e1c9595`](https://github.com/metaplex-foundation/umi/commit/e1c9595dd7f0aeb4469e86a496bc25bbb43a1b5d)]:
+  - @metaplex-foundation/umi-core@0.2.2
+
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [[`d28f4dc`](https://github.com/metaplex-foundation/umi/commit/d28f4dc05c45f35a429fa818e060aed648778718)]:
+  - @metaplex-foundation/umi-core@0.2.1
+
+## 0.2.0
+
+### Minor Changes
+
+- [`b4d681f`](https://github.com/metaplex-foundation/umi/commit/b4d681fd173fb5cc6fe7907c610a23703695c4f6) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Rename Metaplex to Umi
+
+### Patch Changes
+
+- Updated dependencies [[`b4d681f`](https://github.com/metaplex-foundation/umi/commit/b4d681fd173fb5cc6fe7907c610a23703695c4f6)]:
+  - @metaplex-foundation/umi-core@0.2.0
+
+## 0.1.2
+
+### Patch Changes
+
+- [`d3ee23a`](https://github.com/metaplex-foundation/umi/commit/d3ee23aa7ee19a4c6db0e3556e58ee4d12b8ab2b) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Ensure all packages are built before trying to publish
+
+- Updated dependencies [[`d3ee23a`](https://github.com/metaplex-foundation/umi/commit/d3ee23aa7ee19a4c6db0e3556e58ee4d12b8ab2b)]:
+  - @metaplex-foundation/umi-core@0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- [`f30119d`](https://github.com/metaplex-foundation/umi/commit/f30119daf5c51d893c654a064f5fabeb9246aa41) Thanks [@lorisleiva](https://github.com/lorisleiva)! - Publish a new version with changelog and a release tag
+
+- Updated dependencies [[`f30119d`](https://github.com/metaplex-foundation/umi/commit/f30119daf5c51d893c654a064f5fabeb9246aa41)]:
+  - @metaplex-foundation/umi-core@0.1.1

--- a/packages/umi-uploader-cascade/README.md
+++ b/packages/umi-uploader-cascade/README.md
@@ -1,0 +1,9 @@
+# umi-uploader-nft-storage
+
+An uploader implementation relying on Cascade Protocol.
+
+## Installation
+
+```sh
+npm install @metaplex-foundation/umi-uploader-cascade
+```

--- a/packages/umi-uploader-cascade/babel.config.json
+++ b/packages/umi-uploader-cascade/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../babel.config.json"
+}

--- a/packages/umi-uploader-cascade/package.json
+++ b/packages/umi-uploader-cascade/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@metaplex-foundation/umi-uploader-cascade",
+  "version": "0.9.1",
+  "description": "An uploader implementation relying on NFT.Storage",
+  "license": "MIT",
+  "sideEffects": false,
+  "module": "dist/esm/index.mjs",
+  "main": "dist/cjs/index.cjs",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs"
+    }
+  },
+  "files": [
+    "/dist/cjs",
+    "/dist/esm",
+    "/dist/types",
+    "/src"
+  ],
+  "scripts": {
+    "lint": "eslint --ext js,ts,tsx src",
+    "lint:fix": "eslint --fix --ext js,ts,tsx src",
+    "clean": "rimraf dist",
+    "build": "pnpm clean && tsc && tsc -p test/tsconfig.json && rollup -c",
+    "test": "ava"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.7"
+  },
+  "peerDependencies": {
+    "@metaplex-foundation/umi": "workspace:^"
+  },
+  "devDependencies": {
+    "@ava/typescript": "^3.0.1",
+    "@metaplex-foundation/umi": "workspace:^",
+    "@metaplex-foundation/umi-downloader-http": "workspace:^",
+    "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
+    "@metaplex-foundation/umi-http-fetch": "workspace:^",
+    "@metaplex-foundation/umi-rpc-web3js": "workspace:^",
+    "ava": "^5.1.0",
+    "typescript": "^4.5.4",
+    "@types/node-fetch": "^2.6.2",
+    "form-data": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Metaplex Maintainers <contact@metaplex.com>",
+  "homepage": "https://metaplex.com",
+  "repository": {
+    "url": "https://github.com/metaplex-foundation/umi.git"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts",
+    "readmeFile": "./README.md",
+    "displayName": "umi-uploader-cascade"
+  },
+  "ava": {
+    "typescript": {
+      "compile": false,
+      "rewritePaths": {
+        "src/": "dist/test/src/",
+        "test/": "dist/test/test/"
+      }
+    }
+  }
+}

--- a/packages/umi-uploader-cascade/rollup.config.js
+++ b/packages/umi-uploader-cascade/rollup.config.js
@@ -1,0 +1,16 @@
+import { createConfigs } from '../../rollup.config';
+import pkg from './package.json';
+
+export default createConfigs({
+  pkg,
+  builds: [
+    {
+      dir: 'dist/esm',
+      format: 'es',
+    },
+    {
+      dir: 'dist/cjs',
+      format: 'cjs',
+    },
+  ],
+});

--- a/packages/umi-uploader-cascade/src/createCascadeUploader.ts
+++ b/packages/umi-uploader-cascade/src/createCascadeUploader.ts
@@ -1,0 +1,128 @@
+/* eslint-disable no-await-in-loop */
+import {
+  Context,
+  createGenericFileFromJson,
+  GenericFile,
+  lamports,
+  SolAmount,
+  UploaderInterface,
+  UploaderUploadOptions,
+} from '@metaplex-foundation/umi';
+import fetch from 'node-fetch';
+const FormData = require('form-data');
+
+const CASCADE_API_URL = 'https://gateway-api.pastel.network/';
+
+export type CascadeUploaderOptions = {
+  apiKey: string;
+};
+
+export type CascadeUploadedItem = {
+  result_id: string;
+  result_status: string;
+  registration_ticket_txid: string | undefined;
+  original_file_ipfs_link: string | undefined;
+  error: string | undefined;
+};
+
+export type CascadeUploadResponse = {
+  request_id: string;
+  request_status: string;
+  results: CascadeUploadedItem[];
+};
+
+export function createCascadeUploader(
+  context: Pick<Context, 'rpc' | 'payer'>,
+  options: CascadeUploaderOptions = { apiKey: '' }
+): UploaderInterface & {
+  upload2: (
+    files: GenericFile[],
+    options?: UploaderUploadOptions
+  ) => Promise<CascadeUploadedItem[]>;
+} {
+  const { apiKey } = options;
+
+  if (!apiKey) {
+    throw new Error('Cascade Gateway API key is required');
+  }
+
+  const getUploadPrice = async (): Promise<SolAmount> => lamports(0);
+
+  const upload = async (files: GenericFile[]): Promise<string[]> => {
+    const uris: string[] = [];
+
+    const body = new FormData();
+
+    files.forEach((file) => {
+      body.append('files', Buffer.from(file.buffer), file.fileName);
+    });
+
+    try {
+      const res = await fetch(
+        `${CASCADE_API_URL}/api/v1/cascade?make_publicly_accessible=true`,
+        {
+          headers: {
+            Api_key: apiKey,
+          },
+          method: 'POST',
+          body: body,
+        }
+      );
+
+      const data: CascadeUploadResponse = await res.json();
+      data.results.forEach((item) => {
+        if (item.original_file_ipfs_link)
+          uris.push(item.original_file_ipfs_link);
+        else {
+          uris.push('');
+        }
+      });
+    } catch (e) {
+      return [];
+    }
+    console.log(uris);
+    return uris;
+  };
+
+  const upload2 = async (
+    files: GenericFile[]
+  ): Promise<CascadeUploadedItem[]> => {
+    const body = new FormData();
+
+    files.forEach((file) => {
+      body.append('files', Buffer.from(file.buffer), file.fileName);
+    });
+
+    try {
+      const res = await fetch(
+        `${CASCADE_API_URL}/api/v1/cascade?make_publicly_accessible=true`,
+        {
+          headers: {
+            Api_key: apiKey,
+          },
+          method: 'POST',
+          body,
+        }
+      );
+
+      const data: CascadeUploadResponse = await res.json();
+
+      return data.results;
+    } catch (e) {
+      return [];
+    }
+  };
+
+  const uploadJson = async <T>(json: T): Promise<string> => {
+    const file = createGenericFileFromJson(json);
+    const uris = await upload([file]);
+    return uris[0];
+  };
+
+  return {
+    getUploadPrice,
+    upload,
+    uploadJson,
+    upload2,
+  };
+}

--- a/packages/umi-uploader-cascade/src/index.ts
+++ b/packages/umi-uploader-cascade/src/index.ts
@@ -1,0 +1,2 @@
+export * from './createCascadeUploader';
+export * from './plugin';

--- a/packages/umi-uploader-cascade/src/plugin.ts
+++ b/packages/umi-uploader-cascade/src/plugin.ts
@@ -1,0 +1,13 @@
+import type { UmiPlugin } from '@metaplex-foundation/umi';
+import {
+  createCascadeUploader,
+  CascadeUploaderOptions,
+} from './createCascadeUploader';
+
+export const cascadeUploader = (
+  options?: CascadeUploaderOptions
+): UmiPlugin => ({
+  install(umi) {
+    umi.uploader = createCascadeUploader(umi, options);
+  },
+});

--- a/packages/umi-uploader-cascade/test/CascadeUploader.test.ts
+++ b/packages/umi-uploader-cascade/test/CascadeUploader.test.ts
@@ -1,0 +1,69 @@
+import {
+  Context,
+  createGenericFile,
+  createUmi,
+  generatedSignerIdentity,
+  utf8,
+} from '@metaplex-foundation/umi';
+import { httpDownloader } from '@metaplex-foundation/umi-downloader-http';
+import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
+import { fetchHttp } from '@metaplex-foundation/umi-http-fetch';
+import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
+import test from 'ava';
+import { cascadeUploader, CascadeUploaderOptions } from '../src';
+
+test('example test', async (t) => {
+  t.is(typeof cascadeUploader, 'function');
+});
+
+// TODO(loris): Unskip these tests when we can mock the NFT Storage API.
+
+const getContext = (options?: CascadeUploaderOptions): Context =>
+  createUmi().use({
+    install(umi) {
+      umi.use(web3JsRpc('https://api.devnet.solana.com'));
+      umi.use(web3JsEddsa());
+      umi.use(fetchHttp());
+      umi.use(httpDownloader());
+      umi.use(generatedSignerIdentity());
+      umi.use(cascadeUploader(options));
+    },
+  });
+// Use a dummy apiKey since the tests are skipped currently.
+const apiKey = 'testKey';
+
+test.skip('it can upload one file', async (t) => {
+  // Given a Context using NFT.Storage.
+  const context = getContext({ apiKey });
+
+  // When we upload some asset.
+  const [uri] = await context.uploader.upload([
+    createGenericFile('some-image', 'some-image.jpg'),
+  ]);
+
+  // Then the URI should be a valid IPFS URI.
+  t.truthy(uri);
+  t.true(uri.startsWith('https://ipfs.io/'));
+
+  // and it should point to the uploaded asset.
+  const [asset] = await context.downloader.download([uri]);
+  t.is(utf8.deserialize(asset.buffer)[0], 'some-image');
+});
+
+test.skip('it can upload multiple files in batch', async (t) => {
+  // Given a Context using NFT.Storage with a batch size of 1.
+  const context = getContext({ apiKey });
+
+  // When we upload two assets.
+  const uris = await context.uploader.upload([
+    createGenericFile('some-image-A', 'some-image-A.jpg'),
+    createGenericFile('some-image-B', 'some-image-B.jpg'),
+  ]);
+
+  // Then the URIs should point to the uploaded assets in the right order.
+  t.is(uris.length, 2);
+  const [assetA] = await context.downloader.download([uris[0]]);
+  t.is(utf8.deserialize(assetA.buffer)[0], 'some-image-A');
+  const [assetB] = await context.downloader.download([uris[1]]);
+  t.is(utf8.deserialize(assetB.buffer)[0], 'some-image-B');
+});

--- a/packages/umi-uploader-cascade/test/tsconfig.json
+++ b/packages/umi-uploader-cascade/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../dist/test",
+    "declarationDir": null,
+    "declaration": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/umi-uploader-cascade/tsconfig.json
+++ b/packages/umi-uploader-cascade/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "declarationDir": "dist/types"
+  }
+}


### PR DESCRIPTION
Add `umi-uploader-cascade` plugin implementing Pastel Network's Cascade Protocol upload method

This PR introduces a new plugin, umi-uploader-cascade, which integrates the upload method based on Pastel Network's Cascade Protocol (https://cascade.pastel.network/). This plugin extends the functionality of the project by enabling seamless integration with the Cascade Protocol for media / metadata uploads.