### PR TITLE
@metaplex-foundation/umi: Fix react-native serializers dependency export

### DIFF
--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -14,7 +14,7 @@
       "require": "./dist/cjs/index.cjs"
     },
     "./serializers": {
-      "react-native": "./dist/cjs/serializers.cjs"
+      "react-native": "./dist/cjs/serializers.cjs",
       "types": "./dist/types/serializers.d.ts",
       "import": "./dist/esm/serializers.mjs",
       "require": "./dist/cjs/serializers.cjs"

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -16,7 +16,8 @@
     "./serializers": {
       "types": "./dist/types/serializers.d.ts",
       "import": "./dist/esm/serializers.mjs",
-      "require": "./dist/cjs/serializers.cjs"
+      "require": "./dist/cjs/serializers.cjs",
+      "react-native": "./dist/cjs/serializers.cjs"
     }
   },
   "files": [

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -14,10 +14,10 @@
       "require": "./dist/cjs/index.cjs"
     },
     "./serializers": {
+      "react-native": "./dist/cjs/serializers.cjs"
       "types": "./dist/types/serializers.d.ts",
       "import": "./dist/esm/serializers.mjs",
-      "require": "./dist/cjs/serializers.cjs",
-      "react-native": "./dist/cjs/serializers.cjs"
+      "require": "./dist/cjs/serializers.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
Without this, `react-native` projects (like Backpack) can't use the `@metaplex-foundation/umi` package.