### PR TITLE
Add README.md link to JS docs for users redirected here from older tools

### DIFF
--- a/packages/umi/README.md
+++ b/packages/umi/README.md
@@ -3,3 +3,5 @@
 _A Solana Framework for JavaScript clients._
 
 See the [main documentation](https://github.com/metaplex-foundation/umi#readme) for more information.
+
+Just want to mint NFTs? Go straight to the [Token Metadata JS docs](https://developers.metaplex.com/token-metadata/getting-started/js).


### PR DESCRIPTION
Old, NFT specific tools are marked as deprecated, and the docs point to https://www.npmjs.com/package/@metaplex-foundation/umi, but those docs are general Umi docs, rather than NFT docs.