### PR TITLE
fix: should probably use irys gateway instead of arweave

### DIFF
--- a/packages/umi-uploader-irys/src/createIrysUploader.ts
+++ b/packages/umi-uploader-irys/src/createIrysUploader.ts
@@ -149,7 +149,7 @@ export function createIrysUploader(
         throw new AssetUploadFailedError(status);
       }
 
-      return `https://arweave.net/${data.id}`;
+      return `https://gateway.irys.xyz/${data.id}`;
     });
 
     return Promise.all(promises);


### PR DESCRIPTION
Irys uploader returns arweave URLs by default which works in mainnet I guess, but not if the uploader is configured with devnet provider.