### PR TITLE
Attempts to fix umi-bundle-defaults on Vite

### DIFF
--- a/packages/umi-http-fetch/package.json
+++ b/packages/umi-http-fetch/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "browser": "./dist/esm/index.js"
     }
   },
   "files": [
@@ -39,6 +40,7 @@
     "@ava/typescript": "^3.0.1",
     "@metaplex-foundation/umi": "workspace:^",
     "@types/node-fetch": "^2.6.2",
+    "@types/node": "^20.11.18",
     "ava": "^5.1.0",
     "json-server": "^0.17.1"
   },

--- a/packages/umi-http-fetch/src/createFetchHttp.ts
+++ b/packages/umi-http-fetch/src/createFetchHttp.ts
@@ -3,7 +3,15 @@ import {
   HttpRequest,
   HttpResponse,
 } from '@metaplex-foundation/umi';
-import fetch, { BodyInit, RequestInit } from 'node-fetch';
+import type { BodyInit, RequestInit } from 'node-fetch';
+
+let fetch: typeof globalThis.fetch;
+if (typeof window !== 'undefined' && window.fetch) {
+  fetch = window.fetch.bind(window);
+} else {
+  // eslint-disable-next-line global-require
+  fetch = require('node-fetch');
+}
 
 export function createFetchHttp(): HttpInterface {
   return {
@@ -33,7 +41,7 @@ export function createFetchHttp(): HttpInterface {
         body = request.data as BodyInit | undefined;
       }
 
-      const requestInit: RequestInit = {
+      const requestInit: globalThis.RequestInit | RequestInit = {
         method: request.method,
         body,
         headers,
@@ -42,7 +50,7 @@ export function createFetchHttp(): HttpInterface {
         timeout: request.timeout,
       };
 
-      const response = await fetch(request.url, requestInit);
+      const response = await fetch(request.url, requestInit as any);
       const isJsonResponse =
         response.headers.get('content-type')?.includes('application/json') ??
         false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       '@metaplex-foundation/umi':
         specifier: workspace:^
         version: link:../umi
+      '@types/node':
+        specifier: ^20.11.18
+        version: 20.16.5
       '@types/node-fetch':
         specifier: ^2.6.2
         version: 2.6.2
@@ -4870,13 +4873,13 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
       '@types/responselike': 1.0.0
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
 
   /@types/cookie@0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -4885,7 +4888,7 @@ packages:
   /@types/cors@2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
     dev: true
 
   /@types/debug@4.1.7:
@@ -4918,7 +4921,7 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
     dev: true
 
   /@types/hast@2.3.4:
@@ -4947,7 +4950,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
 
   /@types/long@4.0.2:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
@@ -4976,7 +4979,7 @@ packages:
   /@types/node-fetch@2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
       form-data: 3.0.1
     dev: true
 
@@ -4991,8 +4994,10 @@ packages:
     resolution: {integrity: sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==}
     dev: true
 
-  /@types/node@18.11.11:
-    resolution: {integrity: sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==}
+  /@types/node@20.16.5:
+    resolution: {integrity: sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==}
+    dependencies:
+      undici-types: 6.19.8
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -5016,13 +5021,13 @@ packages:
   /@types/resolve@1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
     dev: true
 
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
 
   /@types/retry@0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -5061,7 +5066,7 @@ packages:
   /@types/ws@7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
     dependencies:
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
 
   /@typescript-eslint/eslint-plugin@5.51.0(@typescript-eslint/parser@5.51.0)(eslint@8.33.0)(typescript@4.9.5):
     resolution: {integrity: sha512-wcAwhEWm1RgNd7dxD/o+nnLW8oH+6RK1OGnmbmkj/GGoDPV1WWMVP0FXYQBivKHdwM1pwii3bt//RC62EriIUQ==}
@@ -7433,7 +7438,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -11895,7 +11900,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 18.11.11
+      '@types/node': 20.16.5
       long: 4.0.0
     dev: false
 
@@ -13474,6 +13479,9 @@ packages:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
     dev: true
+
+  /undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}


### PR DESCRIPTION
Attempts to address:

https://github.com/metaplex-foundation/umi/issues/146
https://github.com/metaplex-foundation/umi/issues/147
https://github.com/metaplex-foundation/umi/issues/124

## How to Reproduce

1. **Create a Vite React App:**
   - Use the following command to create a new Vite React app:
     ```sh
     npm create vite@latest my-react-app --template react
     ```
   - Navigate to the project directory:
     ```sh
     cd my-react-app
     ```
   - Install dependencies:
     ```sh
     npm install
     ```

2. **Add Umi and Solana Wallet Adapter:**
   - Install Umi and Solana wallet adapter packages:
     ```sh
     npm install @metaplex-foundation/umi @solana/wallet-adapter-react ...other wallet adapter deps
     ```
   - Install Umi bundle defaults:
     ```sh
     npm install @metaplex-foundation/umi-bundle-defaults
     ```

3. **Configure Umi and Solana Wallet:**
   - Follow the Umi documentation to set up Umi and the Solana wallet adapter in your project. This typically involves:
     - Setting up the Umi provider.
     - Configuring the Solana wallet adapter.
     - Adding necessary imports and configuration code to adapt the wallet adapter for umi.

4. **Run the Application:**
   - Start the Vite development server:
     ```sh
     npm run dev
     ```
   - Observe the application behavior. Issues should be apparent at this stage if you at least are instantiating the UMI wallet adapter and UMI overall (You won't get the error just by installing it, but on usage).

5. **Expected Outcome:**
   - The application should integrate Umi and Solana wallet adapter correctly.
   - Any errors or issues should be logged in the console for further debugging.