### PR TITLE
add wrapNullish() as an available option

### DIFF
--- a/.changeset/rare-deers-sparkle.md
+++ b/.changeset/rare-deers-sparkle.md
@@ -1,0 +1,21 @@
+---
+'@metaplex-foundation/umi-options': minor
+---
+
+`wrapNullable` didn't account for an undefined input and would result in a return value of `some(undefined)` causing `isNone` checks to not pass if `undefined` was the `nullable` value.
+
+```ts
+export const wrapNullable = <T>(nullable: Nullable<T>): Option<T> =>
+  nullable !== null ? some(nullable) : none<T>();
+```
+
+Added a `wrapNullish` function to check for both `null` and undefined which will return the value of `none()` if `null` or `undefined` is the presented `nullish` value.
+
+```ts
+export const wrapNullish = <T>(nullish: Nullish<T>): Option<T> =>
+  nullish !== null && nullish !== undefined ? some(nullish) : none<T>();
+```
+
+- `Nullish` type added.
+- `wrapNullish` function added.
+- Tests for `wrapNullish` added.

--- a/packages/umi-options/src/common.ts
+++ b/packages/umi-options/src/common.ts
@@ -5,6 +5,12 @@
 export type Nullable<T> = T | null;
 
 /**
+ * Defines a type `T` that can also be `null` or `undefined`.
+ * @category Utils — Options
+ */
+export type Nullish<T> = T | null | undefined;
+
+/**
  * An implementation of the Rust Option type in JavaScript.
  * It can be one of the following:
  * - <code>{@link Some}<T></code>: Meaning there is a value of type T.

--- a/packages/umi-options/src/unwrapOption.ts
+++ b/packages/umi-options/src/unwrapOption.ts
@@ -1,4 +1,4 @@
-import { Nullable, Option, isSome, none, some } from './common';
+import { Nullable, Nullish, Option, isSome, none, some } from './common';
 
 /**
  * Unwraps the value of an {@link Option} of type `T`
@@ -23,6 +23,14 @@ export function unwrapOption<T, U = null>(
  */
 export const wrapNullable = <T>(nullable: Nullable<T>): Option<T> =>
   nullable !== null ? some(nullable) : none<T>();
+
+/**
+ * Wraps a nullish value into an {@link Option}.
+ *
+ * @category Utils — Options
+ */
+export const wrapNullish = <T>(nullish: Nullish<T>): Option<T> =>
+  nullish !== null && nullish !== undefined ? some(nullish) : none<T>();
 
 /**
  * Unwraps the value of an {@link Option} of type `T`.

--- a/packages/umi-options/test/unwrapOption.test.ts
+++ b/packages/umi-options/test/unwrapOption.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { none, some, unwrapOption, wrapNullable } from '../src';
+import { none, some, unwrapOption, wrapNullable, wrapNullish } from '../src';
 
 test('it can unwrap an Option as a Nullable', (t) => {
   t.is(unwrapOption(some(42)), 42);
@@ -33,4 +33,13 @@ test('it can wrap a Nullable as an Option', (t) => {
   t.deepEqual(wrapNullable(undefined), some(undefined));
   t.deepEqual(wrapNullable<string>(null), none<string>());
   t.deepEqual(wrapNullable<number>(null), none<number>());
+});
+
+test('it can wrap a Nullish as an Option', (t) => {
+  t.deepEqual(wrapNullish(42), some(42));
+  t.deepEqual(wrapNullish('hello'), some('hello'));
+  t.deepEqual(wrapNullish(false), some(false));
+  t.deepEqual(wrapNullish(undefined), none<undefined>());
+  t.deepEqual(wrapNullish<string>(null), none<string>());
+  t.deepEqual(wrapNullish<number>(null), none<number>());
 });


### PR DESCRIPTION
`wrapNullable` didn't account for an undefined input and would result in a return value of `some(undefined)` causing `isNone` checks to not pass if `undefined` was the `nullable` value.

```ts
export const wrapNullable = <T>(nullable: Nullable<T>): Option<T> =>
  nullable !== null ? some(nullable) : none<T>();
```

Added a `wrapNullish` function to check for both `null` and undefined which will return the value of `none()` if `null` or `undefined` is the presented `nullish`  value.

```ts
export const wrapNullish = <T>(nullish: Nullish<T>): Option<T> =>
  nullish !== null && nullish !== undefined ? some(nullish) : none<T>();
```

- `Nullish` type added.
- `wrapNullish` function added.
- Tests for `wrapNullish` added.

