### PR TITLE
add manifest uploader option to umi uploader interface

### DIFF
--- a/.changeset/metal-planes-smoke.md
+++ b/.changeset/metal-planes-smoke.md
@@ -1,0 +1,5 @@
+---
+'@metaplex-foundation/umi': minor
+---
+
+Introduces a non breaking change to umi uploader interface and adds and optional manifest arg to the UploaderUploadOptions type.

--- a/packages/umi/src/UploaderInterface.ts
+++ b/packages/umi/src/UploaderInterface.ts
@@ -41,6 +41,7 @@ export type UploaderGetUploadPriceOptions = {
 export type UploaderUploadOptions = {
   onProgress?: (percent: number, ...args: any) => void;
   signal?: GenericAbortSignal;
+  manifest?: boolean;
 };
 
 /**


### PR DESCRIPTION
Allows umi uploader plugins to access a `manifest` option in the uploaderInterface options.