### PR TITLE
Remove dependency of outdated library with new function

### DIFF
--- a/packages/umi-eddsa-web3js/package.json
+++ b/packages/umi-eddsa-web3js/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@metaplex-foundation/umi-web3js-adapters": "workspace:^",
-    "@soceanfi/solana-cli-config": "0.2.0",
-    "@noble/curves": "^1.0.0"
+    "@noble/curves": "^1.0.0",
+    "yaml": "^2.7.0"
   },
   "peerDependencies": {
     "@metaplex-foundation/umi": "workspace:^",

--- a/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
+++ b/packages/umi-eddsa-web3js/src/createWeb3JsEddsa.ts
@@ -13,12 +13,12 @@ import {
   toWeb3JsPublicKey,
 } from '@metaplex-foundation/umi-web3js-adapters';
 import { ed25519 } from '@noble/curves/ed25519';
-import { SolanaCliConfig } from '@soceanfi/solana-cli-config';
 import {
   Keypair as Web3JsKeypair,
   PublicKey as Web3JsPublicKey,
 } from '@solana/web3.js';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
+import { loadSolanaKeypair } from './loadSolanaKeypair';
 
 export function createWeb3JsEddsa(): EddsaInterface {
   const generateKeypair = (): Keypair =>
@@ -36,7 +36,7 @@ export function createWeb3JsEddsa(): EddsaInterface {
     );
 
   const createKeypairFromSolanaConfig = (): Keypair =>
-    fromWeb3JsKeypair(SolanaCliConfig.load().loadKeypair());
+    fromWeb3JsKeypair(loadSolanaKeypair());
 
   const isOnCurve = (input: PublicKeyInput): boolean =>
     Web3JsPublicKey.isOnCurve(toWeb3JsPublicKey(publicKey(input)));

--- a/packages/umi-eddsa-web3js/src/loadSolanaKeypair.ts
+++ b/packages/umi-eddsa-web3js/src/loadSolanaKeypair.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2022 Socean Finance
+ * Based on https://github.com/igneous-labs/solana-cli-config
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ *
+ */
+import { Keypair } from '@solana/web3.js';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { parse } from 'yaml';
+
+const DEFAULT_PATH = `${homedir()}/.config/solana/cli/config.yml`;
+
+export function loadSolanaKeypair(path: string = DEFAULT_PATH): Keypair {
+  const { keypair_path: keypairPath } = parse(readFileSync(path, 'utf-8')) as {
+    keypair_path: string;
+  };
+
+  return Keypair.fromSecretKey(
+    Buffer.from(JSON.parse(readFileSync(keypairPath, 'utf-8')) as number[])
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,9 @@ importers:
       '@noble/curves':
         specifier: ^1.0.0
         version: 1.0.0
-      '@soceanfi/solana-cli-config':
-        specifier: 0.2.0
-        version: 0.2.0(@solana/web3.js@1.72.0)
+      yaml:
+        specifier: ^2.7.0
+        version: 2.7.0
     devDependencies:
       '@ava/typescript':
         specifier: ^3.0.1
@@ -4945,16 +4945,6 @@ packages:
   /@sinonjs/text-encoding@0.7.2:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
-
-  /@soceanfi/solana-cli-config@0.2.0(@solana/web3.js@1.72.0):
-    resolution: {integrity: sha512-te44VYk+a5NpYu3Cek6wGo+Lou8zT5DUCos3FA6spr/WBfXb4L1SsmOtxgDCB9GRIuBQJgwDFcydAC+G9oL2PQ==}
-    hasBin: true
-    peerDependencies:
-      '@solana/web3.js': ^1
-    dependencies:
-      '@solana/web3.js': 1.72.0
-      yaml: 2.7.0
-    dev: false
 
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}


### PR DESCRIPTION
This patch removes the dependency on the outdated `@soceanfi/solana-cli-config` and replaces it with a single function that does the same (parse the default Solana config and load the keypair defined in its `keypair_path` property).

It also uses `node:fs` and `node:os` over the old `fs`/`os` which should make it easier to use this library in runtimes that emulate Node. 

In addition, removing this dependency will prevent warnings like these:

```
 WARN  Failed to create bin at /Users/beeman/dev/github/beeman/metaplex-foundation-umi/node_modules/.pnpm/node_modules/.bin/cli. ENOENT: no such file or directory, open '/Users/beeman/dev/github/beeman/metaplex-foundation-umi/node_modules/.pnpm/node_modules/@soceanfi/solana-cli-config/dist/esbuild/cli.js'
 WARN  Failed to create bin at /Users/beeman/dev/github/beeman/metaplex-foundation-umi/packages/umi-eddsa-web3js/node_modules/.bin/cli. ENOENT: no such file or directory, open '/Users/beeman/dev/github/beeman/metaplex-foundation-umi/node_modules/.pnpm/@soceanfi+solana-cli-config@0.2.0_@solana+web3.js@1.72.0/node_modules/@soceanfi/solana-cli-config/dist/esbuild/cli.js'
 WARN  Failed to create bin at /Users/beeman/dev/github/beeman/metaplex-foundation-umi/packages/umi-eddsa-web3js/node_modules/.bin/cli. ENOENT: no such file or directory, open '/Users/beeman/dev/github/beeman/metaplex-foundation-umi/packages/umi-eddsa-web3js/node_modules/@soceanfi/solana-cli-config/dist/esbuild/cli.js'
 ```