### PR TITLE
Fix/turbo package

### DIFF
--- a/.github/actions/install-solana/action.yml
+++ b/.github/actions/install-solana/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Cache Solana Install
       if: ${{ !env.ACT }}
       id: cache-solana-install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: "$HOME/.local/share/solana/install/releases/${{ inputs.solana_version }}"
         key: ${{ runner.os }}-Solana-v${{ inputs.solana_version  }}

--- a/.github/actions/install-solana/action.yml
+++ b/.github/actions/install-solana/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install Solana
       if: ${{ !env.ACT }} && steps.cache-solana-install.cache-hit != 'true'
       run: | 
-        sh -c "$(curl -sSfL https://release.solana.com/v${{ inputs.solana_version }}/install)"
+        sh -c "$(curl -sSfL https://release.anza.xyz/v${{ inputs.solana_version }}/install)"
       shell: bash
 
     - name: Set Active Solana Version 

--- a/packages/umi-uploader-arweave-via-turbo/package.json
+++ b/packages/umi-uploader-arweave-via-turbo/package.json
@@ -4,14 +4,14 @@
   "description": "An uploader implementation relying on Arweave",
   "license": "MIT",
   "sideEffects": false,
-  "module": "dist/esm/index.mjs",
-  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/umi-uploader-arweave-via-turbo/src/index.mjs",
+  "main": "dist/cjs/umi-uploader-arweave-via-turbo/src/index.cjs",
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.cjs"
+      "import": "./dist/esm/umi-uploader-arweave-via-turbo/src/index.mjs",
+      "require": "./dist/cjs/umi-uploader-arweave-via-turbo/src/index.cjs"
     }
   },
   "files": [

--- a/packages/umi-uploader-arweave-via-turbo/package.json
+++ b/packages/umi-uploader-arweave-via-turbo/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
     "@metaplex-foundation/umi": "workspace:^",
-    "@metaplex-foundation/umi-serializers-encodings": "workspace:^",
     "@metaplex-foundation/umi-downloader-http": "workspace:^",
     "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
     "@metaplex-foundation/umi-http-fetch": "workspace:^",

--- a/packages/umi-uploader-arweave-via-turbo/package.json
+++ b/packages/umi-uploader-arweave-via-turbo/package.json
@@ -4,14 +4,14 @@
   "description": "An uploader implementation relying on Arweave",
   "license": "MIT",
   "sideEffects": false,
-  "module": "dist/esm/umi-uploader-arweave-via-turbo/src/index.mjs",
-  "main": "dist/cjs/umi-uploader-arweave-via-turbo/src/index.cjs",
+  "module": "dist/esm/index.mjs",
+  "main": "dist/cjs/index.cjs",
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/umi-uploader-arweave-via-turbo/src/index.mjs",
-      "require": "./dist/cjs/umi-uploader-arweave-via-turbo/src/index.cjs"
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs"
     }
   },
   "files": [
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
     "@metaplex-foundation/umi": "workspace:^",
+    "@metaplex-foundation/umi-serializers-encodings": "workspace:^",
     "@metaplex-foundation/umi-downloader-http": "workspace:^",
     "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
     "@metaplex-foundation/umi-http-fetch": "workspace:^",

--- a/packages/umi-uploader-arweave-via-turbo/rollup.config.js
+++ b/packages/umi-uploader-arweave-via-turbo/rollup.config.js
@@ -3,6 +3,7 @@ import pkg from './package.json';
 
 export default createConfigs({
   pkg,
+  additionalExternals: ['@metaplex-foundation/umi/serializers'],
   builds: [
     {
       dir: 'dist/esm',

--- a/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
+++ b/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
@@ -19,8 +19,9 @@ import {
   isKeypairSigner,
   publicKey,
   sol,
+  base58,
 } from '@metaplex-foundation/umi';
-import { base58 } from '@metaplex-foundation/umi/serializers';
+
 import { toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters';
 import {
   LAMPORTS_PER_SOL,

--- a/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
+++ b/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
@@ -8,21 +8,21 @@ import {
 import {
   Amount,
   Context,
+  createGenericFileFromJson,
+  createSignerFromKeypair,
   GenericFile,
   GenericFileTag,
+  isKeypairSigner,
+  publicKey,
   Signer,
+  sol,
   SolAmount,
   UploaderInterface,
   UsdAmount,
-  createGenericFileFromJson,
-  createSignerFromKeypair,
-  isKeypairSigner,
-  publicKey,
-  sol,
-  base58,
 } from '@metaplex-foundation/umi';
 
 import { toWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters';
+import { base58 } from '@metaplex-foundation/umi/serializers';
 import {
   LAMPORTS_PER_SOL,
   Connection as Web3JsConnection,

--- a/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
+++ b/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
@@ -9,13 +9,13 @@ import { httpDownloader } from '@metaplex-foundation/umi-downloader-http';
 import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
 import { fetchHttp } from '@metaplex-foundation/umi-http-fetch';
 import { web3JsRpc } from '@metaplex-foundation/umi-rpc-web3js';
+import { utf8 } from '@metaplex-foundation/umi/serializers';
 import test from 'ava';
 import {
   ArweaveUploader,
   arweaveUploader,
   ArweaveUploaderOptions,
 } from '../src';
-import { utf8 } from '@metaplex-foundation/umi/serializers';
 
 test('example test', async (t) => {
   t.is(typeof arweaveUploader, 'function');


### PR DESCRIPTION
Resolved a entry point issue where Rollup is generating separate modules. This led to broken or inconsistent entry resolution. Instead of bundling all modules into a single 11MB file, the fix adjusts the entry configuration to correctly preserve module structure and generate accurate entry points.

Also fixed a single lint issue with import ordering.

![image](https://github.com/user-attachments/assets/8b58a2ee-ab72-4940-8034-13780acaac0c)
