### PR TITLE
Read link and get cost units

### DIFF
--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -254,6 +254,9 @@ export function createWeb3JsRpc(
         computeUnitsConsumed: meta.computeUnitsConsumed
           ? BigInt(meta.computeUnitsConsumed)
           : null,
+        costUnits: (meta as any).costUnits
+          ? BigInt((meta as any).costUnits)
+          : null,
         err: meta.err,
       },
     };

--- a/packages/umi/src/Transaction.ts
+++ b/packages/umi/src/Transaction.ts
@@ -133,6 +133,7 @@ export type TransactionMeta = {
   readonly innerInstructions: TransactionMetaInnerInstruction[] | null;
   readonly loadedAddresses: TransactionMetaLoadedAddresses;
   readonly computeUnitsConsumed: bigint | null;
+  readonly costUnits: bigint | null;
   readonly err: TransactionError | null;
 };
 


### PR DESCRIPTION
Add `costUnits` to transaction metadata and RPC response parsing to support the new Solana RPC field.

---
[Slack Thread](https://metaplexfoundation.slack.com/archives/C066W8BUQAY/p1754434291743859?thread_ts=1754434291.743859&cid=C066W8BUQAY)

<a href="https://cursor.com/background-agent?bcId=bc-1af67bfc-2115-4345-b8d6-c949aa0c794a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1af67bfc-2115-4345-b8d6-c949aa0c794a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>