### PR TITLE
Add replaceRecentBlockhash flag to umi

### DIFF
--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -379,6 +379,7 @@ export function createWeb3JsRpc(
           addresses: options.accounts || [],
           encoding: 'base64',
         },
+        replaceRecentBlockhash: options.replaceRecentBlockhash,
       });
       return result.value;
     } catch (error: any) {

--- a/packages/umi/src/RpcInterface.ts
+++ b/packages/umi/src/RpcInterface.ts
@@ -425,6 +425,8 @@ export type RpcSimulateTransactionOptions = RpcBaseOptions & {
   accounts?: PublicKey[];
   /** Optional parameter used to enable signature verification before simulation */
   verifySignatures?: boolean;
+  /** Optional parameter used to replace the transaction's recent blockhash with the latest blockhash */
+  replaceRecentBlockhash?: boolean;
 };
 
 /**
@@ -463,6 +465,7 @@ export type RpcSimulateTransactionResult = {
   logs: Array<string> | null;
   accounts?: Array<RpcSimulateTransactionAccountInfo | null> | null;
   returnData?: RpcSimulateTransactionTransactionReturnData | null;
+  replacementBlockhash?: RpcSimulateTransactionReplacementBlockhash | null;
 };
 
 /**
@@ -492,6 +495,17 @@ export type RpcConfirmTransactionResult = RpcResultWithContext<{
 export type RpcSimulateTransactionTransactionReturnData = {
   data: [string, 'base64'];
   programId: string;
+};
+
+/**
+ * Defines the replacement blockhash information returned when replaceRecentBlockhash is used.
+ * @category Rpc
+ */
+export type RpcSimulateTransactionReplacementBlockhash = {
+  /** The replacement blockhash used for simulation */
+  blockhash: string;
+  /** The last valid block height for the replacement blockhash */
+  lastValidBlockHeight: number;
 };
 
 /**

--- a/packages/umi/src/RpcInterface.ts
+++ b/packages/umi/src/RpcInterface.ts
@@ -505,7 +505,7 @@ export type RpcSimulateTransactionReplacementBlockhash = {
   /** The replacement blockhash used for simulation */
   blockhash: string;
   /** The last valid block height for the replacement blockhash */
-  lastValidBlockHeight: number;
+  lastValidBlockHeight: bigint;
 };
 
 /**


### PR DESCRIPTION
Add `replaceRecentBlockhash` option to `rpc.simulateTransaction` to allow simulating with a fresh blockhash, and ensure `lastValidBlockHeight` in the result is typed as `bigint` for u64 correctness.

---
[Slack Thread](https://metaplexfoundation.slack.com/archives/C066W8BUQAY/p1754434869232609?thread_ts=1754434869.232609&cid=C066W8BUQAY)

<a href="https://cursor.com/background-agent?bcId=bc-a55fa69d-f064-4d47-b718-0bf6973a84a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a55fa69d-f064-4d47-b718-0bf6973a84a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

