### PR TITLE
Adding OptionOrNullish and tests

### DIFF
--- a/packages/umi-options/src/common.ts
+++ b/packages/umi-options/src/common.ts
@@ -75,7 +75,7 @@ export const none = <T>(): Option<T> => ({ __option: 'None' });
  * @category Utils — Options
  */
 export const isOption = <T = unknown>(input: any): input is Option<T> =>
-  input &&
+  !!input &&
   typeof input === 'object' &&
   '__option' in input &&
   ((input.__option === 'Some' && 'value' in input) ||

--- a/packages/umi-options/src/common.ts
+++ b/packages/umi-options/src/common.ts
@@ -30,6 +30,15 @@ export type Option<T> = Some<T> | None;
 export type OptionOrNullable<T> = Option<T> | Nullable<T>;
 
 /**
+ * Defines a looser type that can be used when serializing an {@link Option}.
+ * This allows us to pass null, undefined, or the Option value directly whilst still
+ * supporting the Option type for use-cases that need more type safety.
+ *
+ * @category Utils — Options
+ */
+export type OptionOrNullish<T> = Option<T> | Nullish<T>;
+
+/**
  * Represents an option of type `T` that has a value.
  *
  * @see {@link Option}

--- a/packages/umi-options/test/common.test.ts
+++ b/packages/umi-options/test/common.test.ts
@@ -39,13 +39,13 @@ test('it can check if an option is Some or None', (t) => {
 test('it can check if a value is an Option', (t) => {
   t.true(isOption(some(42)));
   t.true(isOption(none()));
-  t.falsy(isOption(null));
-  t.falsy(isOption(undefined));
-  t.falsy(isOption(42));
-  t.falsy(isOption('hello'));
-  t.falsy(isOption({ value: 42 }));
-  t.falsy(isOption({ __option: 'Some' })); // missing value
-  t.falsy(isOption({ __option: 'Invalid', value: 42 }));
+  t.false(isOption(null));
+  t.false(isOption(undefined));
+  t.false(isOption(42));
+  t.false(isOption('hello'));
+  t.false(isOption({ value: 42 }));
+  t.false(isOption({ __option: 'Some' })); // missing value
+  t.false(isOption({ __option: 'Invalid', value: 42 }));
 });
 
 test('Nullable type accepts value or null', (t) => {

--- a/packages/umi-options/test/common.test.ts
+++ b/packages/umi-options/test/common.test.ts
@@ -1,5 +1,16 @@
 import test from 'ava';
-import { isNone, isSome, none, Option, some } from '../src';
+import {
+  isNone,
+  isOption,
+  isSome,
+  none,
+  Nullable,
+  Nullish,
+  Option,
+  OptionOrNullable,
+  OptionOrNullish,
+  some,
+} from '../src';
 
 test('it can create Some and None options', (t) => {
   const optionA: Option<number> = some(42);
@@ -23,4 +34,60 @@ test('it can check if an option is Some or None', (t) => {
   const optionB = none<number>();
   t.false(isSome(optionB));
   t.true(isNone(optionB));
+});
+
+test('it can check if a value is an Option', (t) => {
+  t.true(isOption(some(42)));
+  t.true(isOption(none()));
+  t.falsy(isOption(null));
+  t.falsy(isOption(undefined));
+  t.falsy(isOption(42));
+  t.falsy(isOption('hello'));
+  t.falsy(isOption({ value: 42 }));
+  t.falsy(isOption({ __option: 'Some' })); // missing value
+  t.falsy(isOption({ __option: 'Invalid', value: 42 }));
+});
+
+test('Nullable type accepts value or null', (t) => {
+  const a: Nullable<number> = 42;
+  const b: Nullable<number> = null;
+
+  t.is(a, 42);
+  t.is(b, null);
+});
+
+test('Nullish type accepts value, null, or undefined', (t) => {
+  const a: Nullish<number> = 42;
+  const b: Nullish<number> = null;
+  const c: Nullish<number> = undefined;
+
+  t.is(a, 42);
+  t.is(b, null);
+  t.is(c, undefined);
+});
+
+test('OptionOrNullable accepts Option, value, or null', (t) => {
+  const a: OptionOrNullable<number> = some(42);
+  const b: OptionOrNullable<number> = none();
+  const c: OptionOrNullable<number> = 42;
+  const d: OptionOrNullable<number> = null;
+
+  t.true(isOption(a));
+  t.true(isOption(b));
+  t.is(c, 42);
+  t.is(d, null);
+});
+
+test('OptionOrNullish accepts Option, value, null, or undefined', (t) => {
+  const a: OptionOrNullish<number> = some(42);
+  const b: OptionOrNullish<number> = none();
+  const c: OptionOrNullish<number> = 42;
+  const d: OptionOrNullish<number> = null;
+  const e: OptionOrNullish<number> = undefined;
+
+  t.true(isOption(a));
+  t.true(isOption(b));
+  t.is(c, 42);
+  t.is(d, null);
+  t.is(e, undefined);
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `OptionOrNullish` and strengthens `isOption` null/undefined handling, with comprehensive tests for option-related types.
> 
> - **Core (`packages/umi-options/src/common.ts`)**:
>   - Add `OptionOrNullish<T>` type (`Option<T> | Nullish<T>`).
>   - Harden `isOption` by using `!!input` to guard against `null`/`undefined`.
> - **Tests (`packages/umi-options/test/common.test.ts`)**:
>   - Add coverage for `isOption` with various invalid inputs.
>   - Add type usage tests for `Nullable`, `Nullish`, `OptionOrNullable`, and new `OptionOrNullish`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 660fac7cbe6b4dc68ee97143584821415ffbfe62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->