### PR TITLE
feat: add umi-rpc-quasar package for in-process SVM test RPC

### DIFF
--- a/packages/umi-rpc-quasar/babel.config.json
+++ b/packages/umi-rpc-quasar/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../babel.config.json"
+}

--- a/packages/umi-rpc-quasar/package.json
+++ b/packages/umi-rpc-quasar/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@metaplex-foundation/umi-rpc-quasar",
+  "version": "0.1.0",
+  "description": "An in-process Solana SVM test RPC for Umi, powered by QuasarSVM",
+  "license": "MIT",
+  "sideEffects": false,
+  "module": "dist/esm/index.mjs",
+  "main": "dist/cjs/index.cjs",
+  "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs"
+    }
+  },
+  "files": [
+    "/dist/cjs",
+    "/dist/esm",
+    "/dist/types",
+    "/src"
+  ],
+  "scripts": {
+    "lint": "eslint --ext js,ts,tsx src",
+    "lint:fix": "eslint --fix --ext js,ts,tsx src",
+    "clean": "rimraf dist",
+    "build": "pnpm clean && tsc && tsc -p test/tsconfig.json && rollup -c",
+    "test": "ava --timeout=1m"
+  },
+  "dependencies": {
+    "@metaplex-foundation/umi-web3js-adapters": "workspace:^",
+    "@blueshift-gg/quasar-svm": "^0.1.4"
+  },
+  "peerDependencies": {
+    "@metaplex-foundation/umi": "workspace:^",
+    "@solana/web3.js": "^1.72.0"
+  },
+  "devDependencies": {
+    "@ava/typescript": "^3.0.1",
+    "@metaplex-foundation/umi": "workspace:^",
+    "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
+    "@metaplex-foundation/umi-serializer-data-view": "workspace:^",
+    "@metaplex-foundation/umi-program-repository": "workspace:^",
+    "@metaplex-foundation/umi-transaction-factory-web3js": "workspace:^",
+    "@metaplex-foundation/umi-http-fetch": "workspace:^",
+    "@metaplex-foundation/umi-storage-mock": "workspace:^",
+    "@solana/web3.js": "^1.72.0",
+    "ava": "^5.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Metaplex Maintainers <contact@metaplex.com>",
+  "homepage": "https://metaplex.com",
+  "repository": {
+    "url": "https://github.com/metaplex-foundation/umi.git"
+  },
+  "ava": {
+    "typescript": {
+      "compile": false,
+      "rewritePaths": {
+        "src/": "dist/test/src/",
+        "test/": "dist/test/test/"
+      }
+    }
+  }
+}

--- a/packages/umi-rpc-quasar/rollup.config.js
+++ b/packages/umi-rpc-quasar/rollup.config.js
@@ -1,0 +1,17 @@
+import { createConfigs } from '../../rollup.config';
+import pkg from './package.json';
+
+export default createConfigs({
+  pkg,
+  additionalExternals: ['@metaplex-foundation/umi/serializers'],
+  builds: [
+    {
+      dir: 'dist/esm',
+      format: 'es',
+    },
+    {
+      dir: 'dist/cjs',
+      format: 'cjs',
+    },
+  ],
+});

--- a/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
+++ b/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
@@ -1,0 +1,582 @@
+import {
+  ACCOUNT_HEADER_SIZE,
+  BlockhashWithExpiryBlockHeight,
+  Cluster,
+  Context,
+  DateTime,
+  dateTime,
+  ErrorWithLogs,
+  lamports,
+  MaybeRpcAccount,
+  ProgramError,
+  PublicKey,
+  RpcAccount,
+  RpcAccountExistsOptions,
+  RpcAirdropOptions,
+  RpcCallOptions,
+  RpcConfirmTransactionOptions,
+  RpcConfirmTransactionResult,
+  RpcGetAccountOptions,
+  RpcGetAccountsOptions,
+  RpcGetBalanceOptions,
+  RpcGetBlockTimeOptions,
+  RpcGetLatestBlockhashOptions,
+  RpcGetProgramAccountsOptions,
+  RpcGetRentOptions,
+  RpcGetSignatureStatusesOptions,
+  RpcGetSlotOptions,
+  RpcGetTransactionOptions,
+  RpcGetTransactionResponseOther,
+  RpcInterface,
+  RpcSendTransactionOptions,
+  RpcSimulateTransactionOptions,
+  RpcSimulateTransactionResult,
+  SolAmount,
+  Transaction,
+  TransactionSignature,
+  TransactionStatus,
+  TransactionVersion,
+  TransactionWithMeta,
+} from '@metaplex-foundation/umi';
+import {
+  fromWeb3JsPublicKey,
+  toWeb3JsPublicKey,
+} from '@metaplex-foundation/umi-web3js-adapters';
+import { base58 } from '@metaplex-foundation/umi/serializers';
+import {
+  PublicKey as Web3JsPublicKey,
+  TransactionInstruction as Web3JsTransactionInstruction,
+} from '@solana/web3.js';
+import type {
+  QuasarSvmInstance,
+  QuasarKeyedAccount,
+} from './quasar-svm';
+
+/**
+ * Internal representation of an account in the QuasarSVM store.
+ */
+interface StoredAccount {
+  owner: Web3JsPublicKey;
+  lamports: bigint;
+  data: Buffer;
+  executable: boolean;
+}
+
+/**
+ * Configuration options for the QuasarSVM RPC.
+ */
+export interface QuasarSvmRpcOptions {
+  /** The rent cost per byte-year in lamports. Defaults to Solana mainnet value. */
+  lamportsPerByteYear?: bigint;
+  /** The initial slot number. Defaults to 1. */
+  initialSlot?: number;
+}
+
+/** The default rent cost: 19.055441478439427 lamports per byte, matching Solana's default. */
+const DEFAULT_RENT_LAMPORTS_PER_BYTE_YEAR = BigInt(3480);
+/** Minimum rent exemption multiplier (2 years). */
+const RENT_EXEMPTION_YEARS = BigInt(2);
+/** Exemption threshold bytes for the rent calculation formula. */
+const RENT_EXEMPTION_THRESHOLD = BigInt(128);
+/** System program ID. */
+const SYSTEM_PROGRAM_ID = new Web3JsPublicKey(
+  '11111111111111111111111111111111'
+);
+
+export function createQuasarSvmRpc(
+  context: Pick<Context, 'programs' | 'transactions'>,
+  svm: QuasarSvmInstance,
+  options: QuasarSvmRpcOptions = {}
+): RpcInterface & { svm: QuasarSvmInstance } {
+  const lamportsPerByteYear =
+    options.lamportsPerByteYear ?? DEFAULT_RENT_LAMPORTS_PER_BYTE_YEAR;
+  let currentSlot = options.initialSlot ?? 1;
+  let blockHeight = 1;
+  let blockhashCounter = 0;
+
+  // In-memory account store: base58 pubkey -> StoredAccount
+  const accountStore = new Map<string, StoredAccount>();
+
+  // Transaction result store: base58 signature -> stored tx result
+  const transactionStore = new Map<
+    string,
+    TransactionWithMeta & RpcGetTransactionResponseOther
+  >();
+
+  // Signature status store
+  const signatureStatuses = new Map<string, TransactionStatus>();
+
+  // ---- Helpers ----
+
+  function generateBlockhash(): string {
+    blockhashCounter += 1;
+    // Generate a deterministic blockhash from the counter
+    const bytes = new Uint8Array(32);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(0, blockhashCounter, true);
+    view.setUint32(4, 0x51415352, true); // "QASR" marker
+    return base58.deserialize(bytes)[0];
+  }
+
+  function getStoredAccount(publicKey: PublicKey): StoredAccount | undefined {
+    return accountStore.get(publicKey as string);
+  }
+
+  function setStoredAccount(
+    publicKey: PublicKey | Web3JsPublicKey,
+    account: StoredAccount
+  ): void {
+    const key =
+      publicKey instanceof Web3JsPublicKey
+        ? fromWeb3JsPublicKey(publicKey)
+        : publicKey;
+    accountStore.set(key as string, account);
+  }
+
+  function toRpcAccount(
+    publicKey: PublicKey,
+    account: StoredAccount
+  ): RpcAccount {
+    return {
+      executable: account.executable,
+      owner: fromWeb3JsPublicKey(account.owner),
+      lamports: lamports(account.lamports),
+      publicKey,
+      data: new Uint8Array(account.data),
+    };
+  }
+
+  function toMaybeRpcAccount(
+    publicKey: PublicKey,
+    account: StoredAccount | undefined
+  ): MaybeRpcAccount {
+    if (account) {
+      return { ...toRpcAccount(publicKey, account), exists: true };
+    }
+    return { exists: false, publicKey };
+  }
+
+  /**
+   * Decompile a Umi Transaction back into web3.js TransactionInstructions
+   * and gather the required KeyedAccountInfo from the store.
+   */
+  function decompileTransaction(transaction: Transaction): {
+    instructions: Web3JsTransactionInstruction[];
+    keyedAccounts: QuasarKeyedAccount[];
+  } {
+    const { message } = transaction;
+    const allAccountKeys = message.accounts.map(toWeb3JsPublicKey);
+    const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = message.header;
+
+    // Determine writable and signer status for each account
+    const numWritableSigned = numRequiredSignatures - numReadonlySignedAccounts;
+    const numUnsigned = allAccountKeys.length - numRequiredSignatures;
+    const numWritableUnsigned = numUnsigned - numReadonlyUnsignedAccounts;
+
+    const isWritable = (index: number): boolean => {
+      if (index < numRequiredSignatures) {
+        return index < numWritableSigned;
+      }
+      return index - numRequiredSignatures < numWritableUnsigned;
+    };
+
+    const isSigner = (index: number): boolean =>
+      index < numRequiredSignatures;
+
+    // Decompile instructions
+    const instructions = message.instructions.map((compiled) => {
+      const programId = allAccountKeys[compiled.programIndex];
+      const keys = compiled.accountIndexes.map((accountIndex) => ({
+        pubkey: allAccountKeys[accountIndex],
+        isSigner: isSigner(accountIndex),
+        isWritable: isWritable(accountIndex),
+      }));
+      return new Web3JsTransactionInstruction({
+        programId,
+        keys,
+        data: Buffer.from(compiled.data),
+      });
+    });
+
+    // Gather all unique accounts referenced by the transaction
+    const seenKeys = new Set<string>();
+    const keyedAccounts: QuasarKeyedAccount[] = [];
+
+    for (const key of allAccountKeys) {
+      const keyStr = key.toBase58();
+      if (seenKeys.has(keyStr)) continue;
+      seenKeys.add(keyStr);
+
+      const stored = accountStore.get(
+        fromWeb3JsPublicKey(key) as string
+      );
+      keyedAccounts.push({
+        accountId: key,
+        accountInfo: stored
+          ? {
+              owner: stored.owner,
+              lamports: stored.lamports,
+              data: stored.data,
+              executable: stored.executable,
+            }
+          : {
+              owner: SYSTEM_PROGRAM_ID,
+              lamports: BigInt(0),
+              data: Buffer.alloc(0),
+              executable: false,
+            },
+      });
+    }
+
+    return { instructions, keyedAccounts };
+  }
+
+  /**
+   * Execute a transaction through QuasarSVM and update the account store.
+   */
+  function executeTransaction(
+    transaction: Transaction,
+    persist: boolean
+  ): {
+    logs: string[];
+    err: any;
+    computeUnits: bigint;
+    returnData: Uint8Array;
+    preBalances: bigint[];
+    postBalances: bigint[];
+  } {
+    const { instructions, keyedAccounts } = decompileTransaction(transaction);
+    const allAccountKeys = transaction.message.accounts;
+
+    // Record pre-balances
+    const preBalances = allAccountKeys.map((key) => {
+      const stored = getStoredAccount(key);
+      return stored ? stored.lamports : BigInt(0);
+    });
+
+    // Execute through QuasarSVM
+    const result = svm.processTransaction(instructions, keyedAccounts);
+
+    const err = result.status !== 0 ? (result.errorMessage ?? 'Transaction failed') : null;
+
+    // Update account store with result accounts if persisting
+    if (persist && result.status === 0) {
+      for (const acct of result.accounts) {
+        setStoredAccount(acct.accountId, {
+          owner: acct.accountInfo.owner,
+          lamports: BigInt(acct.accountInfo.lamports),
+          data: Buffer.from(acct.accountInfo.data),
+          executable: acct.accountInfo.executable,
+        });
+      }
+    }
+
+    // Record post-balances
+    const postBalances = allAccountKeys.map((key) => {
+      const stored = getStoredAccount(key);
+      return stored ? stored.lamports : BigInt(0);
+    });
+
+    return {
+      logs: result.logs,
+      err,
+      computeUnits: result.computeUnits,
+      returnData: result.returnData,
+      preBalances,
+      postBalances,
+    };
+  }
+
+  // Calculate rent exemption for a given number of data bytes
+  function calculateRentExemption(bytes: number): bigint {
+    const totalBytes = BigInt(bytes) + RENT_EXEMPTION_THRESHOLD;
+    return (
+      (lamportsPerByteYear * totalBytes * RENT_EXEMPTION_YEARS) / BigInt(1)
+    );
+  }
+
+  // ---- RPC Interface Implementation ----
+
+  const getAccount = async (
+    publicKey: PublicKey,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetAccountOptions = {}
+  ): Promise<MaybeRpcAccount> =>
+    toMaybeRpcAccount(publicKey, getStoredAccount(publicKey));
+
+  const getAccounts = async (
+    publicKeys: PublicKey[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetAccountsOptions = {}
+  ): Promise<MaybeRpcAccount[]> =>
+    publicKeys.map((pk) => toMaybeRpcAccount(pk, getStoredAccount(pk)));
+
+  const getProgramAccounts = async (
+    programId: PublicKey,
+    options: RpcGetProgramAccountsOptions = {}
+  ): Promise<RpcAccount[]> => {
+    const results: RpcAccount[] = [];
+    const programIdStr = programId as string;
+
+    for (const [key, account] of accountStore.entries()) {
+      if (fromWeb3JsPublicKey(account.owner) !== programIdStr) continue;
+
+      // Apply filters
+      if (options.filters) {
+        let matches = true;
+        for (const filter of options.filters) {
+          if ('dataSize' in filter) {
+            if (account.data.length !== filter.dataSize) {
+              matches = false;
+              break;
+            }
+          } else if ('memcmp' in filter) {
+            const { offset, bytes } = filter.memcmp;
+            const slice = account.data.subarray(
+              offset,
+              offset + bytes.length
+            );
+            if (
+              slice.length !== bytes.length ||
+              !slice.every((b, i) => b === bytes[i])
+            ) {
+              matches = false;
+              break;
+            }
+          }
+        }
+        if (!matches) continue;
+      }
+
+      results.push(toRpcAccount(key as PublicKey, account));
+    }
+    return results;
+  };
+
+  const getBalance = async (
+    publicKey: PublicKey,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetBalanceOptions = {}
+  ): Promise<SolAmount> => {
+    const account = getStoredAccount(publicKey);
+    return lamports(account ? account.lamports : BigInt(0));
+  };
+
+  const getSlot = async (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetSlotOptions = {}
+  ): Promise<number> => currentSlot;
+
+  const getLatestBlockhash = async (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetLatestBlockhashOptions = {}
+  ): Promise<BlockhashWithExpiryBlockHeight> => {
+    blockHeight += 1;
+    return {
+      blockhash: generateBlockhash(),
+      lastValidBlockHeight: blockHeight + 150,
+    };
+  };
+
+  const getGenesisHash = async (): Promise<string> => {
+    // Return a deterministic genesis hash for the test environment
+    const bytes = new Uint8Array(32);
+    bytes.fill(0x01);
+    return base58.deserialize(bytes)[0];
+  };
+
+  const getRent = async (
+    bytes: number,
+    options: RpcGetRentOptions = {}
+  ): Promise<SolAmount> => {
+    if (options.includesHeaderBytes ?? false) {
+      const rentPerByte =
+        calculateRentExemption(0) / BigInt(ACCOUNT_HEADER_SIZE);
+      return lamports(rentPerByte * BigInt(bytes));
+    }
+    return lamports(calculateRentExemption(bytes));
+  };
+
+  const getBlockTime = async (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _slot: number,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetBlockTimeOptions = {}
+  ): Promise<DateTime | null> => dateTime(Math.floor(Date.now() / 1000));
+
+  const getTransaction = async (
+    signature: TransactionSignature,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetTransactionOptions = {}
+  ): Promise<(TransactionWithMeta & RpcGetTransactionResponseOther) | null> => {
+    const sigStr = base58.deserialize(signature)[0];
+    return transactionStore.get(sigStr) ?? null;
+  };
+
+  const getSignatureStatuses = async (
+    signatures: TransactionSignature[],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcGetSignatureStatusesOptions = {}
+  ): Promise<Array<TransactionStatus | null>> =>
+    signatures.map((sig) => {
+      const sigStr = base58.deserialize(sig)[0];
+      return signatureStatuses.get(sigStr) ?? null;
+    });
+
+  const accountExists = async (
+    publicKey: PublicKey,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcAccountExistsOptions = {}
+  ): Promise<boolean> => accountStore.has(publicKey as string);
+
+  const airdrop = async (
+    publicKey: PublicKey,
+    amount: SolAmount,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcAirdropOptions = {}
+  ): Promise<void> => {
+    const existing = getStoredAccount(publicKey);
+    if (existing) {
+      existing.lamports += amount.basisPoints;
+    } else {
+      setStoredAccount(publicKey, {
+        owner: SYSTEM_PROGRAM_ID,
+        lamports: amount.basisPoints,
+        data: Buffer.alloc(0),
+        executable: false,
+      });
+    }
+  };
+
+  const sendTransaction = async (
+    transaction: Transaction,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcSendTransactionOptions = {}
+  ): Promise<TransactionSignature> => {
+    currentSlot += 1;
+
+    const result = executeTransaction(transaction, true);
+    const signature = transaction.signatures[0];
+    const sigStr = base58.deserialize(signature)[0];
+
+    if (result.err) {
+      // Store status as failed
+      signatureStatuses.set(sigStr, {
+        slot: currentSlot,
+        confirmations: null,
+        error: result.err,
+        commitment: 'confirmed',
+      });
+
+      const error = new Error(
+        typeof result.err === 'string' ? result.err : 'Transaction failed'
+      ) as Error & { logs: string[] };
+      error.logs = result.logs;
+
+      let resolvedError: ProgramError | null = null;
+      resolvedError = context.programs.resolveError(
+        error as ErrorWithLogs,
+        transaction
+      );
+      throw resolvedError || error;
+    }
+
+    // Store success status
+    signatureStatuses.set(sigStr, {
+      slot: currentSlot,
+      confirmations: null,
+      error: null,
+      commitment: 'confirmed',
+    });
+
+    // Store the full transaction result
+    transactionStore.set(sigStr, {
+      message: transaction.message,
+      serializedMessage: transaction.serializedMessage,
+      signatures: transaction.signatures,
+      response: {
+        blockTime: BigInt(Math.floor(Date.now() / 1000)),
+        slot: BigInt(currentSlot),
+        version: transaction.message.version as TransactionVersion,
+      },
+      meta: {
+        fee: lamports(5000),
+        logs: result.logs,
+        preBalances: result.preBalances.map(lamports),
+        postBalances: result.postBalances.map(lamports),
+        preTokenBalances: [],
+        postTokenBalances: [],
+        innerInstructions: null,
+        loadedAddresses: { writable: [], readonly: [] },
+        computeUnitsConsumed: result.computeUnits,
+        costUnits: null,
+        err: null,
+      },
+    });
+
+    return signature;
+  };
+
+  const simulateTransaction = async (
+    transaction: Transaction,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcSimulateTransactionOptions = {}
+  ): Promise<RpcSimulateTransactionResult> => {
+    const result = executeTransaction(transaction, false);
+    return {
+      err: result.err,
+      unitsConsumed: Number(result.computeUnits),
+      logs: result.logs,
+    };
+  };
+
+  const confirmTransaction = async (
+    signature: TransactionSignature,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcConfirmTransactionOptions
+  ): Promise<RpcConfirmTransactionResult> => {
+    const sigStr = base58.deserialize(signature)[0];
+    const status = signatureStatuses.get(sigStr);
+    return {
+      context: { slot: currentSlot },
+      value: { err: status?.error ?? null },
+    };
+  };
+
+  const call = async <Result, Params extends any[] | Record<string, any>>(
+    method: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _params?: Params,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: RpcCallOptions = {}
+  ): Promise<Result> => {
+    throw new Error(
+      `QuasarSVM RPC does not support arbitrary RPC calls. Method: ${method}`
+    );
+  };
+
+  return {
+    getEndpoint: () => 'quasar-svm://in-process',
+    getCluster: (): Cluster => 'custom',
+    getAccount,
+    getAccounts,
+    getProgramAccounts,
+    getBlockTime,
+    getGenesisHash,
+    getBalance,
+    getRent,
+    getSlot,
+    getLatestBlockhash,
+    getTransaction,
+    getSignatureStatuses,
+    accountExists,
+    airdrop,
+    call,
+    sendTransaction,
+    simulateTransaction,
+    confirmTransaction,
+    get svm() {
+      return svm;
+    },
+  };
+}

--- a/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
+++ b/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
@@ -200,33 +200,35 @@ export function createQuasarSvmRpc(
 
     // Gather all unique accounts referenced by the transaction
     const seenKeys = new Set<string>();
-    const keyedAccounts: QuasarKeyedAccount[] = [];
+    const keyedAccounts: QuasarKeyedAccount[] = allAccountKeys.reduce(
+      (acc: QuasarKeyedAccount[], key) => {
+        const keyStr = key.toBase58();
+        if (seenKeys.has(keyStr)) return acc;
+        seenKeys.add(keyStr);
 
-    for (const key of allAccountKeys) {
-      const keyStr = key.toBase58();
-      if (seenKeys.has(keyStr)) continue;
-      seenKeys.add(keyStr);
-
-      const stored = accountStore.get(
-        fromWeb3JsPublicKey(key) as string
-      );
-      keyedAccounts.push({
-        accountId: key,
-        accountInfo: stored
-          ? {
-              owner: stored.owner,
-              lamports: stored.lamports,
-              data: stored.data,
-              executable: stored.executable,
-            }
-          : {
-              owner: SYSTEM_PROGRAM_ID,
-              lamports: BigInt(0),
-              data: Buffer.alloc(0),
-              executable: false,
-            },
-      });
-    }
+        const stored = accountStore.get(
+          fromWeb3JsPublicKey(key) as string
+        );
+        acc.push({
+          accountId: key,
+          accountInfo: stored
+            ? {
+                owner: stored.owner,
+                lamports: stored.lamports,
+                data: stored.data,
+                executable: stored.executable,
+              }
+            : {
+                owner: SYSTEM_PROGRAM_ID,
+                lamports: BigInt(0),
+                data: Buffer.alloc(0),
+                executable: false,
+              },
+        });
+        return acc;
+      },
+      []
+    );
 
     return { instructions, keyedAccounts };
   }
@@ -261,14 +263,14 @@ export function createQuasarSvmRpc(
 
     // Update account store with result accounts if persisting
     if (persist && result.status === 0) {
-      for (const acct of result.accounts) {
+      result.accounts.forEach((acct) => {
         setStoredAccount(acct.accountId, {
           owner: acct.accountInfo.owner,
           lamports: BigInt(acct.accountInfo.lamports),
           data: Buffer.from(acct.accountInfo.data),
           executable: acct.accountInfo.executable,
         });
-      }
+      });
     }
 
     // Record post-balances
@@ -315,42 +317,35 @@ export function createQuasarSvmRpc(
     programId: PublicKey,
     options: RpcGetProgramAccountsOptions = {}
   ): Promise<RpcAccount[]> => {
-    const results: RpcAccount[] = [];
     const programIdStr = programId as string;
 
-    for (const [key, account] of accountStore.entries()) {
-      if (fromWeb3JsPublicKey(account.owner) !== programIdStr) continue;
-
-      // Apply filters
-      if (options.filters) {
-        let matches = true;
-        for (const filter of options.filters) {
-          if ('dataSize' in filter) {
-            if (account.data.length !== filter.dataSize) {
-              matches = false;
-              break;
-            }
-          } else if ('memcmp' in filter) {
-            const { offset, bytes } = filter.memcmp;
-            const slice = account.data.subarray(
-              offset,
-              offset + bytes.length
-            );
-            if (
-              slice.length !== bytes.length ||
-              !slice.every((b, i) => b === bytes[i])
-            ) {
-              matches = false;
-              break;
-            }
-          }
+    const matchesFilters = (account: {
+      data: Buffer;
+    }): boolean => {
+      if (!options.filters) return true;
+      return options.filters.every((filter) => {
+        if ('dataSize' in filter) {
+          return account.data.length === filter.dataSize;
         }
-        if (!matches) continue;
-      }
+        if ('memcmp' in filter) {
+          const { offset, bytes } = filter.memcmp;
+          const slice = account.data.subarray(offset, offset + bytes.length);
+          return (
+            slice.length === bytes.length &&
+            slice.every((b: number, i: number) => b === bytes[i])
+          );
+        }
+        return true;
+      });
+    };
 
-      results.push(toRpcAccount(key as PublicKey, account));
-    }
-    return results;
+    return Array.from(accountStore.entries())
+      .filter(
+        ([, account]) =>
+          fromWeb3JsPublicKey(account.owner) === programIdStr &&
+          matchesFilters(account)
+      )
+      .map(([key, account]) => toRpcAccount(key as PublicKey, account));
   };
 
   const getBalance = async (

--- a/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
+++ b/packages/umi-rpc-quasar/src/createQuasarSvmRpc.ts
@@ -47,10 +47,7 @@ import {
   PublicKey as Web3JsPublicKey,
   TransactionInstruction as Web3JsTransactionInstruction,
 } from '@solana/web3.js';
-import type {
-  QuasarSvmInstance,
-  QuasarKeyedAccount,
-} from './quasar-svm';
+import type { QuasarSvmInstance, QuasarKeyedAccount } from './quasar-svm';
 
 /**
  * Internal representation of an account in the QuasarSVM store.
@@ -166,7 +163,11 @@ export function createQuasarSvmRpc(
   } {
     const { message } = transaction;
     const allAccountKeys = message.accounts.map(toWeb3JsPublicKey);
-    const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = message.header;
+    const {
+      numRequiredSignatures,
+      numReadonlySignedAccounts,
+      numReadonlyUnsignedAccounts,
+    } = message.header;
 
     // Determine writable and signer status for each account
     const numWritableSigned = numRequiredSignatures - numReadonlySignedAccounts;
@@ -180,8 +181,7 @@ export function createQuasarSvmRpc(
       return index - numRequiredSignatures < numWritableUnsigned;
     };
 
-    const isSigner = (index: number): boolean =>
-      index < numRequiredSignatures;
+    const isSigner = (index: number): boolean => index < numRequiredSignatures;
 
     // Decompile instructions
     const instructions = message.instructions.map((compiled) => {
@@ -206,9 +206,7 @@ export function createQuasarSvmRpc(
         if (seenKeys.has(keyStr)) return acc;
         seenKeys.add(keyStr);
 
-        const stored = accountStore.get(
-          fromWeb3JsPublicKey(key) as string
-        );
+        const stored = accountStore.get(fromWeb3JsPublicKey(key) as string);
         acc.push({
           accountId: key,
           accountInfo: stored
@@ -259,7 +257,8 @@ export function createQuasarSvmRpc(
     // Execute through QuasarSVM
     const result = svm.processTransaction(instructions, keyedAccounts);
 
-    const err = result.status !== 0 ? (result.errorMessage ?? 'Transaction failed') : null;
+    const err =
+      result.status !== 0 ? result.errorMessage ?? 'Transaction failed' : null;
 
     // Update account store with result accounts if persisting
     if (persist && result.status === 0) {
@@ -319,9 +318,7 @@ export function createQuasarSvmRpc(
   ): Promise<RpcAccount[]> => {
     const programIdStr = programId as string;
 
-    const matchesFilters = (account: {
-      data: Buffer;
-    }): boolean => {
+    const matchesFilters = (account: { data: Buffer }): boolean => {
       if (!options.filters) return true;
       return options.filters.every((filter) => {
         if ('dataSize' in filter) {

--- a/packages/umi-rpc-quasar/src/index.ts
+++ b/packages/umi-rpc-quasar/src/index.ts
@@ -1,0 +1,10 @@
+export * from './plugin';
+export * from './createQuasarSvmRpc';
+export type {
+  QuasarSvmInstance,
+  QuasarKeyedAccount,
+  QuasarAccountInfo,
+  QuasarExecutionResult,
+  QuasarClock,
+  QuasarEpochSchedule,
+} from './quasar-svm';

--- a/packages/umi-rpc-quasar/src/plugin.ts
+++ b/packages/umi-rpc-quasar/src/plugin.ts
@@ -1,0 +1,102 @@
+import { UmiPlugin } from '@metaplex-foundation/umi';
+import { PublicKey } from '@solana/web3.js';
+import type { QuasarSvmInstance } from './quasar-svm';
+import {
+  createQuasarSvmRpc,
+  QuasarSvmRpcOptions,
+} from './createQuasarSvmRpc';
+
+/**
+ * Options for configuring the QuasarSVM RPC plugin.
+ */
+export type QuasarSvmPluginOptions = QuasarSvmRpcOptions & {
+  /** Custom program ELFs to load into the SVM. */
+  programs?: Array<{
+    programId: string;
+    elf: Uint8Array;
+    loaderVersion?: number;
+  }>;
+  /** Whether to include the SPL Token program. Defaults to true. */
+  token?: boolean;
+  /** Whether to include the SPL Token-2022 program. Defaults to false. */
+  token2022?: boolean;
+  /** Whether to include the SPL Associated Token program. Defaults to true. */
+  associatedToken?: boolean;
+};
+
+/**
+ * Creates a Umi plugin that installs the QuasarSVM-based RPC.
+ * This is a direct drop-in replacement for `web3JsRpc()` in test environments.
+ *
+ * @example
+ * ```ts
+ * import { createBaseUmi } from '@metaplex-foundation/umi';
+ * import { quasarSvmRpc } from '@metaplex-foundation/umi-rpc-quasar';
+ *
+ * const umi = createBaseUmi()
+ *   .use(quasarSvmRpc());
+ * ```
+ */
+export function quasarSvmRpc(
+  options: QuasarSvmPluginOptions = {}
+): UmiPlugin {
+  return {
+    install(umi) {
+      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+      const { QuasarSvm } = require('@blueshift-gg/quasar-svm/web3.js');
+      const svmInstance: QuasarSvmInstance = new QuasarSvm();
+
+      // Load default SPL programs unless disabled
+      if (options.token !== false) {
+        svmInstance.addTokenProgram();
+      }
+      if (options.associatedToken !== false) {
+        svmInstance.addAssociatedTokenProgram();
+      }
+      if (options.token2022 === true) {
+        svmInstance.addToken2022Program();
+      }
+
+      // Load custom programs
+      if (options.programs) {
+        for (const program of options.programs) {
+          svmInstance.addProgram(
+            new PublicKey(program.programId),
+            program.elf,
+            program.loaderVersion
+          );
+        }
+      }
+
+      umi.rpc = createQuasarSvmRpc(umi, svmInstance, options);
+    },
+  };
+}
+
+/**
+ * Creates a Umi plugin using an existing QuasarSvm instance.
+ * Useful when you need direct access to the SVM for advanced configuration.
+ *
+ * @example
+ * ```ts
+ * import { QuasarSvm } from '@blueshift-gg/quasar-svm/web3.js';
+ * import { quasarSvmRpcFromInstance } from '@metaplex-foundation/umi-rpc-quasar';
+ *
+ * const svm = new QuasarSvm();
+ * svm.addTokenProgram();
+ * svm.setComputeBudget(400_000n);
+ *
+ * const umi = createBaseUmi()
+ *   .use(quasarSvmRpcFromInstance(svm));
+ * ```
+ */
+export function quasarSvmRpcFromInstance(
+  svmInstance: QuasarSvmInstance,
+  options: QuasarSvmRpcOptions = {}
+): UmiPlugin {
+  return {
+    install(umi) {
+      umi.rpc = createQuasarSvmRpc(umi, svmInstance, options);
+    },
+  };
+}

--- a/packages/umi-rpc-quasar/src/plugin.ts
+++ b/packages/umi-rpc-quasar/src/plugin.ts
@@ -42,7 +42,7 @@ export function quasarSvmRpc(
 ): UmiPlugin {
   return {
     install(umi) {
-      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+      // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/extensions
       const { QuasarSvm } = require('@blueshift-gg/quasar-svm/web3.js');
       const svmInstance: QuasarSvmInstance = new QuasarSvm();
 
@@ -59,13 +59,13 @@ export function quasarSvmRpc(
 
       // Load custom programs
       if (options.programs) {
-        for (const program of options.programs) {
+        options.programs.forEach((program) => {
           svmInstance.addProgram(
             new PublicKey(program.programId),
             program.elf,
             program.loaderVersion
           );
-        }
+        });
       }
 
       umi.rpc = createQuasarSvmRpc(umi, svmInstance, options);

--- a/packages/umi-rpc-quasar/src/plugin.ts
+++ b/packages/umi-rpc-quasar/src/plugin.ts
@@ -1,10 +1,7 @@
 import { UmiPlugin } from '@metaplex-foundation/umi';
 import { PublicKey } from '@solana/web3.js';
 import type { QuasarSvmInstance } from './quasar-svm';
-import {
-  createQuasarSvmRpc,
-  QuasarSvmRpcOptions,
-} from './createQuasarSvmRpc';
+import { createQuasarSvmRpc, QuasarSvmRpcOptions } from './createQuasarSvmRpc';
 
 /**
  * Options for configuring the QuasarSVM RPC plugin.
@@ -37,9 +34,7 @@ export type QuasarSvmPluginOptions = QuasarSvmRpcOptions & {
  *   .use(quasarSvmRpc());
  * ```
  */
-export function quasarSvmRpc(
-  options: QuasarSvmPluginOptions = {}
-): UmiPlugin {
+export function quasarSvmRpc(options: QuasarSvmPluginOptions = {}): UmiPlugin {
   return {
     install(umi) {
       // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/extensions

--- a/packages/umi-rpc-quasar/src/quasar-svm.d.ts
+++ b/packages/umi-rpc-quasar/src/quasar-svm.d.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+
+/**
+ * QuasarSVM's account info representation.
+ * Note: lamports is bigint (unlike web3.js v1's number).
+ */
+export interface QuasarAccountInfo {
+  owner: PublicKey;
+  lamports: bigint;
+  data: Buffer;
+  executable: boolean;
+}
+
+export interface QuasarKeyedAccount {
+  accountId: PublicKey;
+  accountInfo: QuasarAccountInfo;
+}
+
+export interface QuasarExecutionResult {
+  status: number;
+  computeUnits: bigint;
+  executionTimeUs: bigint;
+  returnData: Uint8Array;
+  accounts: QuasarKeyedAccount[];
+  logs: string[];
+  errorMessage: string | null;
+}
+
+export interface QuasarClock {
+  slot: bigint;
+  epochStartTimestamp: bigint;
+  epoch: bigint;
+  leaderScheduleEpoch: bigint;
+  unixTimestamp: bigint;
+}
+
+export interface QuasarEpochSchedule {
+  slotsPerEpoch: bigint;
+  leaderScheduleSlotOffset: bigint;
+  warmup: boolean;
+  firstNormalEpoch: bigint;
+  firstNormalSlot: bigint;
+}
+
+export interface QuasarSvmInstance {
+  free(): void;
+  addProgram(
+    programId: PublicKey,
+    elf: Uint8Array,
+    loaderVersion?: number
+  ): any;
+  addTokenProgram(): any;
+  addToken2022Program(): any;
+  addAssociatedTokenProgram(): any;
+  addSystemProgram(): any;
+  setClock(opts: QuasarClock): void;
+  warpToSlot(slot: bigint): void;
+  setRent(lamportsPerByte: bigint): void;
+  setEpochSchedule(opts: QuasarEpochSchedule): void;
+  setComputeBudget(maxUnits: bigint): void;
+  processInstruction(
+    instructions: TransactionInstruction | TransactionInstruction[],
+    accounts: QuasarKeyedAccount[]
+  ): QuasarExecutionResult;
+  processTransaction(
+    instructions: TransactionInstruction[],
+    accounts: QuasarKeyedAccount[]
+  ): QuasarExecutionResult;
+}

--- a/packages/umi-rpc-quasar/test/quasarSvmRpc.test.ts
+++ b/packages/umi-rpc-quasar/test/quasarSvmRpc.test.ts
@@ -1,0 +1,189 @@
+import test from 'ava';
+import {
+  createBaseUmi,
+  generateSigner,
+  sol,
+  Umi,
+} from '@metaplex-foundation/umi';
+import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
+import { dataViewSerializer } from '@metaplex-foundation/umi-serializer-data-view';
+import { defaultProgramRepository } from '@metaplex-foundation/umi-program-repository';
+import { web3JsTransactionFactory } from '@metaplex-foundation/umi-transaction-factory-web3js';
+import { fetchHttp } from '@metaplex-foundation/umi-http-fetch';
+import { mockStorage } from '@metaplex-foundation/umi-storage-mock';
+import { generatedSignerIdentity } from '@metaplex-foundation/umi';
+import { quasarSvmRpc } from '../src';
+
+function createTestUmi(): Umi {
+  return createBaseUmi()
+    .use(dataViewSerializer())
+    .use(defaultProgramRepository())
+    .use(fetchHttp())
+    .use(web3JsEddsa())
+    .use(web3JsTransactionFactory())
+    .use(mockStorage())
+    .use(quasarSvmRpc())
+    .use(generatedSignerIdentity());
+}
+
+test('it returns the quasar-svm endpoint', (t) => {
+  const umi = createTestUmi();
+  t.is(umi.rpc.getEndpoint(), 'quasar-svm://in-process');
+});
+
+test('it returns custom cluster', (t) => {
+  const umi = createTestUmi();
+  t.is(umi.rpc.getCluster(), 'custom');
+});
+
+test('it can airdrop SOL', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  await umi.rpc.airdrop(signer.publicKey, sol(10));
+  const balance = await umi.rpc.getBalance(signer.publicKey);
+  t.is(balance.basisPoints, sol(10).basisPoints);
+});
+
+test('it can airdrop SOL multiple times', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  await umi.rpc.airdrop(signer.publicKey, sol(5));
+  await umi.rpc.airdrop(signer.publicKey, sol(3));
+  const balance = await umi.rpc.getBalance(signer.publicKey);
+  t.is(balance.basisPoints, sol(8).basisPoints);
+});
+
+test('it returns zero balance for unknown accounts', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  const balance = await umi.rpc.getBalance(signer.publicKey);
+  t.is(balance.basisPoints, BigInt(0));
+});
+
+test('it can check if account exists', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  t.false(await umi.rpc.accountExists(signer.publicKey));
+  await umi.rpc.airdrop(signer.publicKey, sol(1));
+  t.true(await umi.rpc.accountExists(signer.publicKey));
+});
+
+test('it can get account info after airdrop', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  await umi.rpc.airdrop(signer.publicKey, sol(1));
+  const account = await umi.rpc.getAccount(signer.publicKey);
+  t.true(account.exists);
+  if (account.exists) {
+    t.is(account.lamports.basisPoints, sol(1).basisPoints);
+    t.false(account.executable);
+  }
+});
+
+test('it returns non-existing account', async (t) => {
+  const umi = createTestUmi();
+  const signer = generateSigner(umi);
+
+  const account = await umi.rpc.getAccount(signer.publicKey);
+  t.false(account.exists);
+});
+
+test('it can get multiple accounts', async (t) => {
+  const umi = createTestUmi();
+  const s1 = generateSigner(umi);
+  const s2 = generateSigner(umi);
+  const s3 = generateSigner(umi);
+
+  await umi.rpc.airdrop(s1.publicKey, sol(1));
+  await umi.rpc.airdrop(s2.publicKey, sol(2));
+
+  const accounts = await umi.rpc.getAccounts([
+    s1.publicKey,
+    s2.publicKey,
+    s3.publicKey,
+  ]);
+
+  t.is(accounts.length, 3);
+  t.true(accounts[0].exists);
+  t.true(accounts[1].exists);
+  t.false(accounts[2].exists);
+});
+
+test('it provides a slot', async (t) => {
+  const umi = createTestUmi();
+  const slot = await umi.rpc.getSlot();
+  t.true(slot >= 1);
+});
+
+test('it provides a latest blockhash', async (t) => {
+  const umi = createTestUmi();
+  const blockhash = await umi.rpc.getLatestBlockhash();
+  t.truthy(blockhash.blockhash);
+  t.true(blockhash.lastValidBlockHeight > 0);
+});
+
+test('it provides different blockhashes on each call', async (t) => {
+  const umi = createTestUmi();
+  const bh1 = await umi.rpc.getLatestBlockhash();
+  const bh2 = await umi.rpc.getLatestBlockhash();
+  t.not(bh1.blockhash, bh2.blockhash);
+});
+
+test('it provides a genesis hash', async (t) => {
+  const umi = createTestUmi();
+  const hash = await umi.rpc.getGenesisHash();
+  t.truthy(hash);
+});
+
+test('it calculates rent', async (t) => {
+  const umi = createTestUmi();
+  const rent = await umi.rpc.getRent(100);
+  t.true(rent.basisPoints > BigInt(0));
+});
+
+test('it provides a block time', async (t) => {
+  const umi = createTestUmi();
+  const blockTime = await umi.rpc.getBlockTime(1);
+  t.truthy(blockTime);
+});
+
+test('it returns null for unknown transactions', async (t) => {
+  const umi = createTestUmi();
+  const fakeSignature = new Uint8Array(64);
+  const tx = await umi.rpc.getTransaction(fakeSignature);
+  t.is(tx, null);
+});
+
+test('it returns null for unknown signature statuses', async (t) => {
+  const umi = createTestUmi();
+  const fakeSignature = new Uint8Array(64);
+  const statuses = await umi.rpc.getSignatureStatuses([fakeSignature]);
+  t.is(statuses.length, 1);
+  t.is(statuses[0], null);
+});
+
+test('it throws on arbitrary RPC calls', async (t) => {
+  const umi = createTestUmi();
+  await t.throwsAsync(() => umi.rpc.call('getVersion'), {
+    message: /does not support arbitrary RPC calls/,
+  });
+});
+
+test('it confirms transactions immediately', async (t) => {
+  const umi = createTestUmi();
+  const fakeSignature = new Uint8Array(64);
+  const blockhash = await umi.rpc.getLatestBlockhash();
+  const result = await umi.rpc.confirmTransaction(fakeSignature, {
+    strategy: {
+      type: 'blockhash',
+      ...blockhash,
+    },
+  });
+  t.truthy(result.context);
+  t.is(result.value.err, null);
+});

--- a/packages/umi-rpc-quasar/test/tsconfig.json
+++ b/packages/umi-rpc-quasar/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../dist/test",
+    "declarationDir": null,
+    "declaration": false,
+    "emitDeclarationOnly": false
+  }
+}

--- a/packages/umi-rpc-quasar/tsconfig.json
+++ b/packages/umi-rpc-quasar/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.typedoc.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "declarationDir": "dist/types"
+  },
+  "typedocOptions": {
+    "name": "umi-rpc-quasar"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,46 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0(@ava/typescript@3.0.1)
 
+  packages/umi-rpc-quasar:
+    dependencies:
+      '@blueshift-gg/quasar-svm':
+        specifier: ^0.1.4
+        version: 0.1.4(@solana/web3.js@1.98.0)
+      '@metaplex-foundation/umi-web3js-adapters':
+        specifier: workspace:^
+        version: link:../umi-web3js-adapters
+    devDependencies:
+      '@ava/typescript':
+        specifier: ^3.0.1
+        version: 3.0.1
+      '@metaplex-foundation/umi':
+        specifier: workspace:^
+        version: link:../umi
+      '@metaplex-foundation/umi-eddsa-web3js':
+        specifier: workspace:^
+        version: link:../umi-eddsa-web3js
+      '@metaplex-foundation/umi-http-fetch':
+        specifier: workspace:^
+        version: link:../umi-http-fetch
+      '@metaplex-foundation/umi-program-repository':
+        specifier: workspace:^
+        version: link:../umi-program-repository
+      '@metaplex-foundation/umi-serializer-data-view':
+        specifier: workspace:^
+        version: link:../umi-serializer-data-view
+      '@metaplex-foundation/umi-storage-mock':
+        specifier: workspace:^
+        version: link:../umi-storage-mock
+      '@metaplex-foundation/umi-transaction-factory-web3js':
+        specifier: workspace:^
+        version: link:../umi-transaction-factory-web3js
+      '@solana/web3.js':
+        specifier: ^1.72.0
+        version: 1.98.0
+      ava:
+        specifier: ^5.1.0
+        version: 5.1.0(@ava/typescript@3.0.1)
+
   packages/umi-rpc-web3js:
     dependencies:
       '@metaplex-foundation/umi-web3js-adapters':
@@ -945,20 +985,20 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/chunked-blob-reader-native@3.208.0:
     resolution: {integrity: sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==}
     dependencies:
       '@aws-sdk/util-base64': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/chunked-blob-reader@3.188.0:
     resolution: {integrity: sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/client-s3@3.264.0:
@@ -1143,7 +1183,7 @@ packages:
       '@aws-sdk/util-user-agent-node': 3.259.0
       '@aws-sdk/util-utf8': 3.254.0
       fast-xml-parser: 4.0.11
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -1156,7 +1196,7 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-config-provider': 3.208.0
       '@aws-sdk/util-middleware': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-env@3.257.0:
@@ -1165,7 +1205,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-imds@3.259.0:
@@ -1176,7 +1216,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/url-parser': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-ini@3.264.0:
@@ -1191,7 +1231,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -1209,7 +1249,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -1221,7 +1261,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/credential-provider-sso@3.264.0:
@@ -1233,7 +1273,7 @@ packages:
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/token-providers': 3.264.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     dev: true
@@ -1244,7 +1284,7 @@ packages:
     dependencies:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/eventstream-codec@3.258.0:
@@ -1262,7 +1302,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-serde-universal': 3.258.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/eventstream-serde-config-resolver@3.257.0:
@@ -1270,7 +1310,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/eventstream-serde-node@3.258.0:
@@ -1279,7 +1319,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-serde-universal': 3.258.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/eventstream-serde-universal@3.258.0:
@@ -1288,7 +1328,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-codec': 3.258.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/fetch-http-handler@3.257.0:
@@ -1298,7 +1338,7 @@ packages:
       '@aws-sdk/querystring-builder': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-base64': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/hash-blob-browser@3.257.0:
@@ -1307,7 +1347,7 @@ packages:
       '@aws-sdk/chunked-blob-reader': 3.188.0
       '@aws-sdk/chunked-blob-reader-native': 3.208.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/hash-node@3.257.0:
@@ -1317,7 +1357,7 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-buffer-from': 3.208.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/hash-stream-node@3.257.0:
@@ -1326,21 +1366,21 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/invalid-dependency@3.257.0:
     resolution: {integrity: sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/is-array-buffer@3.201.0:
     resolution: {integrity: sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/md5-js@3.258.0:
@@ -1348,7 +1388,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-bucket-endpoint@3.259.0:
@@ -1359,7 +1399,7 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-arn-parser': 3.208.0
       '@aws-sdk/util-config-provider': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-content-length@3.257.0:
@@ -1368,7 +1408,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-endpoint@3.264.0:
@@ -1382,7 +1422,7 @@ packages:
       '@aws-sdk/url-parser': 3.257.0
       '@aws-sdk/util-config-provider': 3.208.0
       '@aws-sdk/util-middleware': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-expect-continue@3.257.0:
@@ -1391,7 +1431,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-flexible-checksums@3.259.0:
@@ -1404,7 +1444,7 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-host-header@3.257.0:
@@ -1413,7 +1453,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-location-constraint@3.257.0:
@@ -1421,7 +1461,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-logger@3.257.0:
@@ -1429,7 +1469,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-recursion-detection@3.257.0:
@@ -1438,7 +1478,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-retry@3.259.0:
@@ -1450,7 +1490,7 @@ packages:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-middleware': 3.257.0
       '@aws-sdk/util-retry': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
       uuid: 8.3.2
     dev: true
 
@@ -1461,7 +1501,7 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-arn-parser': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-sdk-sts@3.257.0:
@@ -1473,7 +1513,7 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/signature-v4': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-serde@3.257.0:
@@ -1481,7 +1521,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-signing@3.257.0:
@@ -1493,7 +1533,7 @@ packages:
       '@aws-sdk/signature-v4': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-middleware': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-ssec@3.257.0:
@@ -1501,14 +1541,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-stack@3.257.0:
     resolution: {integrity: sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/middleware-user-agent@3.257.0:
@@ -1517,7 +1557,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/node-config-provider@3.259.0:
@@ -1527,7 +1567,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/shared-ini-file-loader': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/node-http-handler@3.257.0:
@@ -1538,7 +1578,7 @@ packages:
       '@aws-sdk/protocol-http': 3.257.0
       '@aws-sdk/querystring-builder': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/property-provider@3.257.0:
@@ -1546,7 +1586,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/protocol-http@3.257.0:
@@ -1554,7 +1594,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/querystring-builder@3.257.0:
@@ -1563,7 +1603,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-uri-escape': 3.201.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/querystring-parser@3.257.0:
@@ -1571,7 +1611,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/service-error-classification@3.257.0:
@@ -1584,7 +1624,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/signature-v4-multi-region@3.264.0:
@@ -1600,7 +1640,7 @@ packages:
       '@aws-sdk/signature-v4': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-arn-parser': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/signature-v4@3.257.0:
@@ -1613,7 +1653,7 @@ packages:
       '@aws-sdk/util-middleware': 3.257.0
       '@aws-sdk/util-uri-escape': 3.201.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/smithy-client@3.261.0:
@@ -1622,7 +1662,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-stack': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/token-providers@3.264.0:
@@ -1642,7 +1682,7 @@ packages:
     resolution: {integrity: sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/url-parser@3.257.0:
@@ -1650,14 +1690,14 @@ packages:
     dependencies:
       '@aws-sdk/querystring-parser': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-arn-parser@3.208.0:
     resolution: {integrity: sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-base64@3.208.0:
@@ -1665,20 +1705,20 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/util-buffer-from': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-body-length-browser@3.188.0:
     resolution: {integrity: sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-body-length-node@3.208.0:
     resolution: {integrity: sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-buffer-from@3.208.0:
@@ -1686,14 +1726,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/is-array-buffer': 3.201.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-config-provider@3.208.0:
     resolution: {integrity: sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-defaults-mode-browser@3.261.0:
@@ -1703,7 +1743,7 @@ packages:
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
       bowser: 2.11.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-defaults-mode-node@3.261.0:
@@ -1715,7 +1755,7 @@ packages:
       '@aws-sdk/node-config-provider': 3.259.0
       '@aws-sdk/property-provider': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-endpoints@3.257.0:
@@ -1723,28 +1763,28 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-hex-encoding@3.201.0:
     resolution: {integrity: sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-locate-window@3.208.0:
     resolution: {integrity: sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-middleware@3.257.0:
     resolution: {integrity: sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-retry@3.257.0:
@@ -1752,7 +1792,7 @@ packages:
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@aws-sdk/service-error-classification': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-stream-browser@3.258.0:
@@ -1763,7 +1803,7 @@ packages:
       '@aws-sdk/util-base64': 3.208.0
       '@aws-sdk/util-hex-encoding': 3.201.0
       '@aws-sdk/util-utf8': 3.254.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-stream-node@3.257.0:
@@ -1773,7 +1813,7 @@ packages:
       '@aws-sdk/node-http-handler': 3.257.0
       '@aws-sdk/types': 3.257.0
       '@aws-sdk/util-buffer-from': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-uri-escape@3.201.0:
@@ -1788,7 +1828,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.257.0
       bowser: 2.11.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-user-agent-node@3.259.0:
@@ -1802,13 +1842,13 @@ packages:
     dependencies:
       '@aws-sdk/node-config-provider': 3.259.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-utf8-browser@3.259.0:
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-utf8@3.254.0:
@@ -1816,7 +1856,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-sdk/util-buffer-from': 3.208.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/util-waiter@3.257.0:
@@ -1825,14 +1865,14 @@ packages:
     dependencies:
       '@aws-sdk/abort-controller': 3.257.0
       '@aws-sdk/types': 3.257.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@aws-sdk/xml-builder@3.201.0:
     resolution: {integrity: sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@babel/code-frame@7.18.6:
@@ -3166,10 +3206,78 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
+  /@blueshift-gg/quasar-svm-darwin-arm64@0.1.4:
+    resolution: {integrity: sha512-kGjuQk+0F0Q/RlGoC5E9PY7jios/aU82H4kIuyEIoiW9amb4fyxjdOmJ9SEzN1Ir0zZNKbeWvN2FKGlTY7z2sA==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@blueshift-gg/quasar-svm-darwin-x64@0.1.4:
+    resolution: {integrity: sha512-blymlaCBO43BWju/rZQgmGffLEv2MHGEWQTwaQrLq5R5FVv82XyvNt3w6qcZaMMLIWgGCH4wvT1MOpUITNrIPg==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@blueshift-gg/quasar-svm-linux-arm64-gnu@0.1.4:
+    resolution: {integrity: sha512-JpaAlC1B/Bn7BOCvT6ayo/FoHBQ9csQ/4fhHmo051KSTl8R7pVRT5LpJkj4sCtGsK39E71q12gimDMC2nFeY0w==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@blueshift-gg/quasar-svm-linux-x64-gnu@0.1.4:
+    resolution: {integrity: sha512-NNjyelSKlJNMX+4UDhrK/3qw8jUIxls46fwq8ph22P5Y4XNYFS9nZtkl6XbYrCH4gBdj9b/WLT1dL8LXxB15Xw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@blueshift-gg/quasar-svm-win32-x64-msvc@0.1.4:
+    resolution: {integrity: sha512-Lb5WGHmsVDN8rAG6tmeFEFfNqElzpnu/L7q0EdrBJ33dpvNu0c37uek7sj33oQ1iVBP2GxMiyDBpj270VKC0oQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@blueshift-gg/quasar-svm@0.1.4(@solana/web3.js@1.98.0):
+    resolution: {integrity: sha512-GBzPlCXeeW5yA5cMSsBIF2y+ehDdmYgUchwAXaSM3ArQbB0vaLslXj9QmADUanmxGIemyXtoM1IeJ/8/I0ddMQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@solana/addresses': ^5.5.0
+      '@solana/instructions': ^5.5.0
+      '@solana/rpc-types': ^6.2.0
+      '@solana/web3.js': '>=2.0.0'
+    peerDependenciesMeta:
+      '@solana/addresses':
+        optional: true
+      '@solana/instructions':
+        optional: true
+      '@solana/rpc-types':
+        optional: true
+      '@solana/web3.js':
+        optional: true
+    dependencies:
+      '@solana/web3.js': 1.98.0
+      koffi: 2.15.2
+    optionalDependencies:
+      '@blueshift-gg/quasar-svm-darwin-arm64': 0.1.4
+      '@blueshift-gg/quasar-svm-darwin-x64': 0.1.4
+      '@blueshift-gg/quasar-svm-linux-arm64-gnu': 0.1.4
+      '@blueshift-gg/quasar-svm-linux-x64-gnu': 0.1.4
+      '@blueshift-gg/quasar-svm-win32-x64-msvc': 0.1.4
+    dev: false
+
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/config': 2.3.0
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -3187,7 +3295,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.3(patch_hash=psjonfb234vefryc6hzdzm5ple):
     resolution: {integrity: sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.5
       '@changesets/types': 5.2.1
@@ -3291,7 +3399,7 @@ packages:
   /@changesets/get-release-plan@3.0.16:
     resolution: {integrity: sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/assemble-release-plan': 5.2.3(patch_hash=psjonfb234vefryc6hzdzm5ple)
       '@changesets/config': 2.3.0
       '@changesets/pre': 1.0.14
@@ -3307,7 +3415,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -3332,7 +3440,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -3342,7 +3450,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -3363,7 +3471,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -4748,7 +4856,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -4767,7 +4875,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.3.8
+      semver: 7.7.3
       tar: 6.1.13
     transitivePeerDependencies:
       - encoding
@@ -4931,7 +5039,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.8
+      semver: 7.7.3
     dev: true
 
   /@npmcli/move-file@1.1.2:
@@ -6801,7 +6909,7 @@ packages:
       eslint: 8.33.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.33.0)
-      semver: 7.3.8
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7254,12 +7362,12 @@ packages:
       acorn: 8.15.0
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.8.1):
+  /acorn-jsx@5.3.2(acorn@8.15.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.15.0
     dev: true
 
   /acorn-walk@8.2.0:
@@ -8002,7 +8110,7 @@ packages:
   /borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
     dependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.2
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -8660,7 +8768,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.3.8
+      semver: 7.7.3
       well-known-symbols: 2.0.0
     dev: true
 
@@ -9118,7 +9226,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       globby: 13.1.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-glob: 4.0.3
       is-path-cwd: 3.0.0
       is-path-inside: 4.0.0
@@ -9864,14 +9972,9 @@ packages:
       '@esbuild/win32-x64': 0.25.11
     dev: true
 
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-    dev: true
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -10125,8 +10228,8 @@ packages:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2(acorn@8.8.1)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 3.3.0
     dev: true
 
@@ -10738,7 +10841,7 @@ packages:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -12176,6 +12279,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /koffi@2.15.2:
+    resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
+    requiresBuild: true
+    dev: false
+
   /kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
@@ -12353,7 +12461,7 @@ packages:
     resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-promise: 2.2.2
       lodash: 4.17.21
       pify: 3.0.0
@@ -12769,8 +12877,8 @@ packages:
   /micromark-extension-mdxjs@1.0.0:
     resolution: {integrity: sha512-TZZRZgeHvtgm+IhtgC2+uDMR7h8eTKF0QUX9YsgoL9+bADBpBY6SiLvWqnBlLbCEevITmTqmEuY3FoxMKVs1rQ==}
     dependencies:
-      acorn: 8.8.1
-      acorn-jsx: 5.3.2(acorn@8.8.1)
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       micromark-extension-mdx-expression: 1.0.4
       micromark-extension-mdx-jsx: 1.0.3
       micromark-extension-mdx-md: 1.0.0
@@ -13118,7 +13226,7 @@ packages:
   /mlly@1.1.0:
     resolution: {integrity: sha512-cwzBrBfwGC1gYJyfcy8TcZU1f+dbH/T+TuOhtYP2wLv/Fb51/uV7HJQfBPtEupZ2ORLRU1EKFS/QfS3eo9+kBQ==}
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.15.0
       pathe: 1.1.0
       pkg-types: 1.0.1
       ufo: 1.0.1
@@ -14361,7 +14469,7 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -14721,10 +14829,10 @@ packages:
   /rpc-websockets@7.5.0:
     resolution: {integrity: sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==}
     dependencies:
-      '@babel/runtime': 7.20.6
+      '@babel/runtime': 7.26.0
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 8.11.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      ws: 8.18.2(bufferutil@4.0.7)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.7
       utf-8-validate: 5.0.10
@@ -14761,7 +14869,7 @@ packages:
   /rxjs@7.6.0:
     resolution: {integrity: sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -14797,7 +14905,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       immutable: 4.1.0
       source-map-js: 1.0.2
     dev: true
@@ -15956,7 +16064,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 14.18.33
-      acorn: 8.8.1
+      acorn: 8.15.0
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -15995,6 +16103,7 @@ packages:
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
 
   /tslib@2.7.0:
     resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
@@ -16024,7 +16133,7 @@ packages:
       smartwrap: 2.0.2
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
-      yargs: 17.6.2
+      yargs: 17.7.2
     dev: true
 
   /turbo-darwin-64@1.9.1:
@@ -16343,7 +16452,7 @@ packages:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.21.4
-      escalade: 3.1.1
+      escalade: 3.2.0
       picocolors: 1.0.0
     dev: true
 
@@ -16535,7 +16644,7 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.15.0
       acorn-walk: 8.2.0
     dev: true
 
@@ -16939,21 +17048,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws@8.11.0(bufferutil@4.0.7)(utf-8-validate@5.0.10):
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dependencies:
-      bufferutil: 4.0.7
-      utf-8-validate: 5.0.10
-
   /ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
     engines: {node: '>=10.0.0'}
@@ -17129,7 +17223,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cliui: 7.0.4
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -17142,7 +17236,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
@@ -17155,13 +17249,12 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: false
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
Adds a new package that wraps QuasarSVM as a drop-in replacement for
the web3js RPC in test environments. This enables parallel test
execution without needing a local Solana validator, significantly
improving test speed and isolation.

Key features:
- Full RpcInterface implementation backed by in-process QuasarSVM
- In-memory account store with airdrop, getAccount, getBalance, etc.
- Transaction execution via QuasarSVM with pre/post balance tracking
- Plugin API (quasarSvmRpc) for easy swap with web3JsRpc
- Support for custom program ELFs and SPL token programs
- 19 passing tests

https://claude.ai/code/session_01EVMdRp9gsxzsoN8wzardLP