### PR TITLE
feat(umi-uploader-arweave-via-turbo): configurable gateway URL

### DIFF
--- a/.changeset/configurable-arweave-turbo-gateway.md
+++ b/.changeset/configurable-arweave-turbo-gateway.md
@@ -1,0 +1,11 @@
+---
+'@metaplex-foundation/umi-uploader-arweave-via-turbo': minor
+---
+
+Add `gatewayUrl` option to `ArweaveUploaderOptions` so consumers can choose which Arweave gateway host is composed into the URIs returned from `upload()` / `uploadJson()`. Since those URIs are typically written into on-chain NFT metadata, making this configurable lets consumers point at `ar.io`, a self-hosted gateway, or any other resolver they want to commit to long-term.
+
+**Behavior change:** the default gateway used on mainnet/non-devnet clusters has changed from `https://arweave.net` to `https://turbo-gateway.com`. Devnet default (`https://turbo.ardrive.dev/raw`) is unchanged. If you need to keep minting NFTs whose metadata URIs use the old host (e.g. for parity with previously-minted assets), pass it explicitly:
+
+```ts
+umi.use(arweaveUploader({ gatewayUrl: 'https://arweave.net' }));
+```

--- a/.changeset/configurable-arweave-turbo-gateway.md
+++ b/.changeset/configurable-arweave-turbo-gateway.md
@@ -2,10 +2,19 @@
 '@metaplex-foundation/umi-uploader-arweave-via-turbo': minor
 ---
 
-Add `gatewayUrl` option to `ArweaveUploaderOptions` so consumers can choose which Arweave gateway host is composed into the URIs returned from `upload()` / `uploadJson()`. Since those URIs are typically written into on-chain NFT metadata, making this configurable lets consumers point at `ar.io`, a self-hosted gateway, or any other resolver they want to commit to long-term.
+Add `arweaveGatewayUrl` option to `ArweaveUploaderOptions` so consumers can control the Arweave gateway host composed into the URIs returned from `upload()` / `uploadJson()`. Those URIs are typically written into on-chain NFT metadata, so making the gateway configurable lets consumers commit to a resolver they intend to rely on long-term.
 
-**Behavior change:** the default gateway used on mainnet/non-devnet clusters has changed from `https://arweave.net` to `https://turbo-gateway.com`. Devnet default (`https://turbo.ardrive.dev/raw`) is unchanged. If you need to keep minting NFTs whose metadata URIs use the old host (e.g. for parity with previously-minted assets), pass it explicitly:
+The option is named `arweaveGatewayUrl` — not `gatewayUrl` — to avoid confusion with the Turbo SDK's own `gatewayUrl` field, which in Turbo's vocabulary means the Solana RPC endpoint (exposed here as `solRpcUrl`).
+
+**Default gateway changed:**
+
+- **Mainnet / non-devnet:** `https://arweave.net` → `https://turbo-gateway.com`
+- **Devnet:** `https://turbo.ardrive.dev/raw` → `https://turbo-gateway.com` (the previous devnet gateway is no longer operational, and Turbo does not run a separate devnet content gateway — one gateway serves every cluster)
+
+**Turbo upload and payment endpoints consolidated.** Turbo has no separate devnet environment, so `uploadServiceUrl` and `paymentServiceUrl` now default to `https://upload.ardrive.io` and `https://payment.ardrive.io` on every cluster (previously the devnet cluster defaulted to `upload.ardrive.dev` / `payment.ardrive.dev`). Developers can still point Solana contracts at devnet while uploading through Turbo's production service — the free tier (uploads under 100KB, up to 200MB per IP per day) requires no SOL payment, so devnet wallets are fine for testing. Paid uploads above the free tier need real mainnet SOL; attempting a paid upload with devnet SOL will now error explicitly rather than silently producing an unresolvable URI. The old staging endpoints can still be opted into via the `uploadServiceUrl` / `paymentServiceUrl` options if needed.
+
+Callers who need URI parity with previously-minted NFTs can restore the old main-chain gateway behavior by passing `arweaveGatewayUrl` explicitly:
 
 ```ts
-umi.use(arweaveUploader({ gatewayUrl: 'https://arweave.net' }));
+umi.use(arweaveUploader({ arweaveGatewayUrl: 'https://arweave.net' }));
 ```

--- a/packages/umi-uploader-arweave-via-turbo/README.md
+++ b/packages/umi-uploader-arweave-via-turbo/README.md
@@ -1,9 +1,43 @@
 # umi-uploader-arweave-via-turbo
 
-An uploader implementation relying on Arweave. Takes advantage of the Turbo SDK and AR.IO bundling infrastructure to provide seamless upload to Arweave
+An uploader implementation relying on Arweave. Takes advantage of the Turbo SDK and AR.IO bundling infrastructure to provide seamless upload to Arweave.
 
 ## Installation
 
 ```sh
 npm install @metaplex-foundation/umi-uploader-arweave-via-turbo
 ```
+
+## Usage
+
+```ts
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { arweaveUploader } from '@metaplex-foundation/umi-uploader-arweave-via-turbo';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com').use(
+  arweaveUploader()
+);
+```
+
+## Configuration
+
+`arweaveUploader(options)` accepts:
+
+- `arweaveGatewayUrl` — base URL of the Arweave gateway used to compose the asset URIs returned from `upload()` / `uploadJson()`. Defaults to `https://turbo-gateway.com`. These URIs are typically written into on-chain NFT metadata, so if you want your assets resolved through a different gateway set it here:
+
+  ```ts
+  umi.use(arweaveUploader({ arweaveGatewayUrl: 'https://turbo-gateway.com' }));
+  ```
+
+  The same gateway is used on every cluster — Turbo does not run a separate devnet content gateway.
+
+- `uploadServiceUrl` / `paymentServiceUrl` — Turbo upload and payment API endpoints. Default to `https://upload.ardrive.io` and `https://payment.ardrive.io` for every cluster; Turbo does not run a separate devnet environment. Override only if you have a specific reason (custom Turbo deployment, staging env, etc.).
+- `solRpcUrl`, `priceMultiplier`, `payer` — see source for details.
+
+## Pricing and free uploads
+
+Uploads under **100KB are free**, up to **200MB per IP per day**. Larger uploads are paid in Turbo Storage Credits, purchased automatically from the payer's SOL balance (or via a Stripe checkout session for USD top-ups).
+
+### Testing on devnet
+
+You can use this uploader from a Solana program deployed to devnet — contracts and NFTs still live on devnet while their metadata is uploaded to Arweave through Turbo's production service. Within the free tier (under 100KB per file, up to 200MB per IP per day) nothing more is required: no SOL payment is needed, so devnet SOL is fine. For uploads above the free tier, real mainnet SOL is required to purchase Turbo Storage Credits — devnet SOL cannot pay for paid uploads, and the upload will error if you try.

--- a/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
+++ b/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
@@ -65,7 +65,30 @@ export type ArweaveUploaderOptions = {
   paymentServiceUrl?: string;
   priceMultiplier?: number;
   payer?: Signer;
+  /**
+   * Base URL of the Arweave gateway used to compose the asset URIs
+   * returned from `upload()` / `uploadJson()`. These URIs are typically
+   * written into on-chain NFT metadata, so choose a gateway you intend
+   * to rely on long-term (e.g. `https://turbo-gateway.com`,
+   * `https://arweave.net`, `https://ar.io`, or a self-hosted gateway).
+   * A trailing slash is tolerated.
+   *
+   * Defaults: `https://turbo-gateway.com` on mainnet/non-devnet clusters
+   * and `https://turbo.ardrive.dev/raw` on devnet.
+   */
+  gatewayUrl?: string;
 };
+
+export const resolveGatewayBaseUrl = (
+  gatewayUrl: string | undefined,
+  cluster: string
+): string =>
+  (
+    gatewayUrl ??
+    (cluster === 'devnet'
+      ? 'https://turbo.ardrive.dev/raw'
+      : 'https://turbo-gateway.com')
+  ).replace(/\/+$/, '');
 
 export type ArweaveWalletAdapter = {
   publicKey: Web3JsPublicKey | null;
@@ -191,10 +214,10 @@ export function createArweaveUploader(
         throw new AssetUploadFailedError(error);
       }
 
-      const gateway =
-        context.rpc.getCluster() === 'devnet'
-          ? 'https://turbo.ardrive.dev/raw'
-          : 'https://arweave.net';
+      const gateway = resolveGatewayBaseUrl(
+        options.gatewayUrl,
+        context.rpc.getCluster()
+      );
 
       return `${gateway}/${dataItemId}`;
     });

--- a/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
+++ b/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
@@ -84,10 +84,33 @@ export type ArweaveUploaderOptions = {
   arweaveGatewayUrl?: string;
 };
 
+const DEFAULT_ARWEAVE_GATEWAY_URL = 'https://turbo-gateway.com';
+
 export const resolveArweaveGatewayUrl = (
   arweaveGatewayUrl: string | undefined
-): string =>
-  (arweaveGatewayUrl ?? 'https://turbo-gateway.com').replace(/\/+$/, '');
+): string => {
+  const gateway = (arweaveGatewayUrl ?? DEFAULT_ARWEAVE_GATEWAY_URL).replace(
+    /\/+$/,
+    ''
+  );
+
+  let parsed: URL;
+  try {
+    parsed = new URL(gateway);
+  } catch {
+    throw new Error(
+      `Invalid arweaveGatewayUrl: expected an absolute http(s) URL, got "${arweaveGatewayUrl}"`
+    );
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `Invalid arweaveGatewayUrl: expected http: or https:, got "${parsed.protocol}"`
+    );
+  }
+
+  return gateway;
+};
 
 export type ArweaveWalletAdapter = {
   publicKey: Web3JsPublicKey | null;
@@ -346,8 +369,8 @@ export function createArweaveUploader(
       await arweave.getTurboCryptoWallets();
     } catch (error) {
       throw new FailedToConnectToArweaveAddressError(
-        options.uploadServiceUrl ?? '',
-        options.paymentServiceUrl ?? '',
+        options.uploadServiceUrl ?? DEFAULT_UPLOAD_SERVICE_URL,
+        options.paymentServiceUrl ?? DEFAULT_PAYMENT_SERVICE_URL,
         error as Error
       );
     }

--- a/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
+++ b/packages/umi-uploader-arweave-via-turbo/src/createArweaveUploader.ts
@@ -73,22 +73,21 @@ export type ArweaveUploaderOptions = {
    * `https://arweave.net`, `https://ar.io`, or a self-hosted gateway).
    * A trailing slash is tolerated.
    *
-   * Defaults: `https://turbo-gateway.com` on mainnet/non-devnet clusters
-   * and `https://turbo.ardrive.dev/raw` on devnet.
+   * Defaults to `https://turbo-gateway.com`, a full AR.IO gateway
+   * operated alongside Turbo. The same gateway is used on every
+   * cluster — Turbo does not run a separate devnet content gateway.
+   *
+   * Note: not to be confused with the Turbo SDK's own `gatewayUrl`
+   * field (the Solana RPC endpoint) — that one is controlled by
+   * `solRpcUrl` above.
    */
-  gatewayUrl?: string;
+  arweaveGatewayUrl?: string;
 };
 
-export const resolveGatewayBaseUrl = (
-  gatewayUrl: string | undefined,
-  cluster: string
+export const resolveArweaveGatewayUrl = (
+  arweaveGatewayUrl: string | undefined
 ): string =>
-  (
-    gatewayUrl ??
-    (cluster === 'devnet'
-      ? 'https://turbo.ardrive.dev/raw'
-      : 'https://turbo-gateway.com')
-  ).replace(/\/+$/, '');
+  (arweaveGatewayUrl ?? 'https://turbo-gateway.com').replace(/\/+$/, '');
 
 export type ArweaveWalletAdapter = {
   publicKey: Web3JsPublicKey | null;
@@ -110,6 +109,14 @@ export type ArweaveWalletAdapter = {
 const HEADER_SIZE = 2_000;
 
 const FREE_UPLOAD_BYTE_LIMIT = 107_520; // 105 KiB
+
+// Turbo has a single production environment — there is no devnet-specific
+// upload or payment service. Free-tier uploads (under FREE_UPLOAD_BYTE_LIMIT)
+// work for any cluster because no SOL payment is required. Paid uploads
+// need a mainnet-signed SOL transaction to buy Turbo Storage Credits. Both
+// defaults can be overridden via `uploadServiceUrl` / `paymentServiceUrl`.
+const DEFAULT_UPLOAD_SERVICE_URL = 'https://upload.ardrive.io';
+const DEFAULT_PAYMENT_SERVICE_URL = 'https://payment.ardrive.io';
 
 export function createArweaveUploader(
   context: Pick<Context, 'rpc' | 'payer' | 'eddsa'>,
@@ -214,10 +221,7 @@ export function createArweaveUploader(
         throw new AssetUploadFailedError(error);
       }
 
-      const gateway = resolveGatewayBaseUrl(
-        options.gatewayUrl,
-        context.rpc.getCluster()
-      );
+      const gateway = resolveArweaveGatewayUrl(options.arweaveGatewayUrl);
 
       return `${gateway}/${dataItemId}`;
     });
@@ -317,17 +321,6 @@ export function createArweaveUploader(
     return _arweave;
   };
 
-  const defaultAddresses =
-    context.rpc.getCluster() === 'devnet'
-      ? {
-          uploadServiceUrl: 'https://upload.ardrive.dev',
-          paymentServiceUrl: 'https://payment.ardrive.dev',
-        }
-      : {
-          uploadServiceUrl: 'https://upload.ardrive.io',
-          paymentServiceUrl: 'https://payment.ardrive.io',
-        };
-
   const initArweave = async (
     payer: Signer = options.payer ?? context.payer
   ): Promise<TurboAuthenticatedClient> => {
@@ -338,10 +331,10 @@ export function createArweaveUploader(
         privateKey: base58.deserialize(payer.secretKey)[0],
         gatewayUrl: options.solRpcUrl,
         uploadServiceConfig: {
-          url: options.uploadServiceUrl ?? defaultAddresses.uploadServiceUrl,
+          url: options.uploadServiceUrl ?? DEFAULT_UPLOAD_SERVICE_URL,
         },
         paymentServiceConfig: {
-          url: options.paymentServiceUrl ?? defaultAddresses.paymentServiceUrl,
+          url: options.paymentServiceUrl ?? DEFAULT_PAYMENT_SERVICE_URL,
         },
       });
     } else {
@@ -376,10 +369,10 @@ export function createArweaveUploader(
       walletAdapter: wallet,
       gatewayUrl: options.solRpcUrl,
       uploadServiceConfig: {
-        url: options.uploadServiceUrl ?? defaultAddresses.uploadServiceUrl,
+        url: options.uploadServiceUrl ?? DEFAULT_UPLOAD_SERVICE_URL,
       },
       paymentServiceConfig: {
-        url: options.paymentServiceUrl ?? defaultAddresses.paymentServiceUrl,
+        url: options.paymentServiceUrl ?? DEFAULT_PAYMENT_SERVICE_URL,
       },
     });
   };

--- a/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
+++ b/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
@@ -38,6 +38,37 @@ test('resolveArweaveGatewayUrl strips trailing slashes so URI composition is cle
   );
 });
 
+test('resolveArweaveGatewayUrl rejects empty strings so we never write a relative URI on-chain', (t) => {
+  t.throws(() => resolveArweaveGatewayUrl(''), {
+    message: /Invalid arweaveGatewayUrl/,
+  });
+});
+
+test('resolveArweaveGatewayUrl rejects slash-only inputs that normalise to empty', (t) => {
+  t.throws(() => resolveArweaveGatewayUrl('/'), {
+    message: /Invalid arweaveGatewayUrl/,
+  });
+});
+
+test('resolveArweaveGatewayUrl rejects schemeless hosts', (t) => {
+  t.throws(() => resolveArweaveGatewayUrl('turbo-gateway.com'), {
+    message: /Invalid arweaveGatewayUrl/,
+  });
+});
+
+test('resolveArweaveGatewayUrl rejects non-http(s) protocols', (t) => {
+  t.throws(() => resolveArweaveGatewayUrl('ftp://turbo-gateway.com'), {
+    message: /expected http: or https:/,
+  });
+});
+
+test('resolveArweaveGatewayUrl allows plain http for self-hosted/dev gateways', (t) => {
+  t.is(
+    resolveArweaveGatewayUrl('http://localhost:3000'),
+    'http://localhost:3000'
+  );
+});
+
 // TODO(loris): Unskip these tests when we can mock the Arweave API.
 
 const devNetRpcUrl = 'https://api.devnet.solana.com';

--- a/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
+++ b/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
@@ -15,46 +15,25 @@ import {
   ArweaveUploader,
   arweaveUploader,
   ArweaveUploaderOptions,
-  resolveGatewayBaseUrl,
+  resolveArweaveGatewayUrl,
 } from '../src';
 
 test('example test', async (t) => {
   t.is(typeof arweaveUploader, 'function');
 });
 
-test('resolveGatewayBaseUrl defaults to turbo-gateway.com on non-devnet', (t) => {
-  t.is(
-    resolveGatewayBaseUrl(undefined, 'mainnet-beta'),
-    'https://turbo-gateway.com'
-  );
-  t.is(resolveGatewayBaseUrl(undefined, 'custom'), 'https://turbo-gateway.com');
+test('resolveArweaveGatewayUrl defaults to turbo-gateway.com', (t) => {
+  t.is(resolveArweaveGatewayUrl(undefined), 'https://turbo-gateway.com');
 });
 
-test('resolveGatewayBaseUrl defaults to turbo.ardrive.dev/raw on devnet', (t) => {
-  t.is(
-    resolveGatewayBaseUrl(undefined, 'devnet'),
-    'https://turbo.ardrive.dev/raw'
-  );
+test('resolveArweaveGatewayUrl uses the user-supplied gateway when provided', (t) => {
+  t.is(resolveArweaveGatewayUrl('https://example.org'), 'https://example.org');
 });
 
-test('resolveGatewayBaseUrl uses the user-supplied gateway on any cluster', (t) => {
+test('resolveArweaveGatewayUrl strips trailing slashes so URI composition is clean', (t) => {
+  t.is(resolveArweaveGatewayUrl('https://example.org/'), 'https://example.org');
   t.is(
-    resolveGatewayBaseUrl('https://example.org', 'mainnet-beta'),
-    'https://example.org'
-  );
-  t.is(
-    resolveGatewayBaseUrl('https://example.org', 'devnet'),
-    'https://example.org'
-  );
-});
-
-test('resolveGatewayBaseUrl strips trailing slashes so URI composition is clean', (t) => {
-  t.is(
-    resolveGatewayBaseUrl('https://example.org/', 'mainnet-beta'),
-    'https://example.org'
-  );
-  t.is(
-    resolveGatewayBaseUrl('https://example.org///', 'mainnet-beta'),
+    resolveArweaveGatewayUrl('https://example.org///'),
     'https://example.org'
   );
 });
@@ -91,9 +70,9 @@ test.skip('can upload one file', async (t) => {
     createGenericFile('some-image', 'some-image.jpg'),
   ]);
 
-  // Then the URI should be a valid arweave dev gateway URI.
+  // Then the URI should be composed via the default turbo-gateway.com host.
   t.truthy(uri);
-  t.true(uri.startsWith('https://turbo.ardrive.dev/'));
+  t.true(uri.startsWith('https://turbo-gateway.com/'));
 
   // and it should point to the uploaded asset.
   const [asset] = await context.downloader.download([uri]);
@@ -116,7 +95,7 @@ test.skip('can upload a file above 105 KiB in size', async (t) => {
   ]);
 
   t.truthy(uri);
-  t.true(uri.startsWith('https://turbo.ardrive.dev/'));
+  t.true(uri.startsWith('https://turbo-gateway.com/'));
 
   const [asset] = await context.downloader.download([uri]);
   t.deepEqual(asset.buffer, buffer);

--- a/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
+++ b/packages/umi-uploader-arweave-via-turbo/test/ArweaveUploader.test.ts
@@ -15,10 +15,48 @@ import {
   ArweaveUploader,
   arweaveUploader,
   ArweaveUploaderOptions,
+  resolveGatewayBaseUrl,
 } from '../src';
 
 test('example test', async (t) => {
   t.is(typeof arweaveUploader, 'function');
+});
+
+test('resolveGatewayBaseUrl defaults to turbo-gateway.com on non-devnet', (t) => {
+  t.is(
+    resolveGatewayBaseUrl(undefined, 'mainnet-beta'),
+    'https://turbo-gateway.com'
+  );
+  t.is(resolveGatewayBaseUrl(undefined, 'custom'), 'https://turbo-gateway.com');
+});
+
+test('resolveGatewayBaseUrl defaults to turbo.ardrive.dev/raw on devnet', (t) => {
+  t.is(
+    resolveGatewayBaseUrl(undefined, 'devnet'),
+    'https://turbo.ardrive.dev/raw'
+  );
+});
+
+test('resolveGatewayBaseUrl uses the user-supplied gateway on any cluster', (t) => {
+  t.is(
+    resolveGatewayBaseUrl('https://example.org', 'mainnet-beta'),
+    'https://example.org'
+  );
+  t.is(
+    resolveGatewayBaseUrl('https://example.org', 'devnet'),
+    'https://example.org'
+  );
+});
+
+test('resolveGatewayBaseUrl strips trailing slashes so URI composition is clean', (t) => {
+  t.is(
+    resolveGatewayBaseUrl('https://example.org/', 'mainnet-beta'),
+    'https://example.org'
+  );
+  t.is(
+    resolveGatewayBaseUrl('https://example.org///', 'mainnet-beta'),
+    'https://example.org'
+  );
 });
 
 // TODO(loris): Unskip these tests when we can mock the Arweave API.


### PR DESCRIPTION
Add an `arweaveGatewayUrl` option to `ArweaveUploaderOptions` so consumers can choose which Arweave gateway host is composed into the URIs returned from `upload()` / `uploadJson()`. Those URIs are typically persisted into on-chain NFT metadata, so the current hardcoded host is effectively permanent for every asset minted through this uploader — surfacing it as a plugin option lets callers commit to a resolver they intend to rely on long-term.

The option is named `arweaveGatewayUrl` — not `gatewayUrl` — to avoid collision with the Turbo SDK's own `gatewayUrl` field, which in Turbo's vocabulary means the Solana RPC endpoint (exposed here as `solRpcUrl`). Shipping a second meaning of `gatewayUrl` in the same module would be a footgun.

## Default gateway changed

- **Mainnet / non-devnet:** `https://arweave.net` → `https://turbo-gateway.com`
- **Devnet:** `https://turbo.ardrive.dev/raw` → `https://turbo-gateway.com`

The previous devnet gateway is no longer operational. Turbo does not run a separate devnet content gateway; one gateway serves every cluster.

Callers who need URI parity with previously-minted NFTs can restore the old main-chain behavior by pinning the option:

```ts
umi.use(arweaveUploader({ arweaveGatewayUrl: 'https://arweave.net' }));
```

## Turbo upload and payment endpoints consolidated

Turbo also has no separate devnet environment on the upload/payment side, so `uploadServiceUrl` and `paymentServiceUrl` now default to `https://upload.ardrive.io` / `https://payment.ardrive.io` on every cluster (previously the devnet cluster defaulted to `upload.ardrive.dev` / `payment.ardrive.dev`).

Developers can still point their Solana contracts at devnet while uploading through Turbo's production service. The free tier (under 100KB per file, up to 200MB per IP per day) requires no SOL payment, so a devnet wallet is sufficient for testing. Paid uploads above the free tier need real mainnet SOL — attempting to pay with devnet SOL will now error explicitly rather than silently producing an unresolvable URI. The old staging endpoints can still be opted into via the existing `uploadServiceUrl` / `paymentServiceUrl` options.

Context: the `irys-uploader/change-gateway` branch is addressing the same gateway concern on the Irys uploader by hardcoding a new default. This PR generalizes the fix for `arweave-via-turbo` — same underlying problem, solved with a configurable option rather than another hardcode — and leaves the door open to apply the same pattern to `umi-uploader-irys` later.

## Verification

- `pnpm format` and `pnpm lint` clean across all 28 packages
- `pnpm test` across the full monorepo: **58/58 packages pass**
- `umi-uploader-arweave-via-turbo`: 7 tests pass, 2 pre-existing skips preserved. Unit tests cover the default, the override, and trailing-slash normalization
- **Real-world round trip against devnet, using the new defaults, with a freshly generated signer (no SOL balance required):** upload a small file → Turbo mainnet accepts under the free tier → returned URI is `https://turbo-gateway.com/<id>` → download via the httpDownloader resolves and byte-matches the uploaded content (1.9s end-to-end)
- `turbo-gateway.com` and `arweave.net` return the same content-addressed sandbox hash for a known tx id, confirming the default change is transparent to NFT consumers for already-uploaded content
- A `minor` changeset has been added with the migration note