### PR TITLE
Refactor transaction parser to return structured ParsedTransaction

### DIFF
--- a/packages/umi/src/TransactionParser.ts
+++ b/packages/umi/src/TransactionParser.ts
@@ -2,17 +2,23 @@ import type { PublicKey } from '@metaplex-foundation/umi-public-keys';
 import type { Serializer } from '@metaplex-foundation/umi-serializers';
 import type { Context } from './Context';
 import type { AccountMeta, Instruction } from './Instruction';
-import type { Transaction } from './Transaction';
+import type {
+  Blockhash,
+  CompiledAddressLookupTable,
+  Transaction,
+  TransactionMessage,
+  TransactionSignature,
+  TransactionVersion,
+} from './Transaction';
 
 /**
  * Defines the discriminator bytes used to identify an instruction.
  * @category Transaction Parser
  */
 export type InstructionDiscriminator = {
-  /** The raw discriminator bytes to match against. */
+  /** The raw discriminator bytes to match against. The discriminator occupies
+   *  exactly `bytes.length` bytes at the start of the instruction data. */
   bytes: Uint8Array;
-  /** The number of bytes the discriminator occupies at the start of instruction data. */
-  size: number;
 };
 
 /**
@@ -44,6 +50,8 @@ export type ParsedAccountMeta = AccountMeta & {
  * @category Transaction Parser
  */
 export type ParsedInstruction = {
+  /** Zero-based position of this instruction within the transaction. */
+  index: number;
   /** The registered name of the program, or 'unknown'. */
   programName: string;
   /** The public key of the program. */
@@ -51,10 +59,87 @@ export type ParsedInstruction = {
   /** The name of the instruction, or 'unknown'. */
   instructionName: string;
   /** The deserialized instruction data, or the raw Uint8Array if unknown. */
-  data: object | Uint8Array;
+  data: Record<string, unknown> | Uint8Array;
   /** The accounts used by the instruction, with optional names. */
   accounts: ParsedAccountMeta[];
 };
+
+/**
+ * The result of parsing a full transaction: transaction-level metadata
+ * alongside the parsed instruction list.
+ * @category Transaction Parser
+ */
+export type ParsedTransaction = {
+  /** Legacy or v0. */
+  version: TransactionVersion;
+  /** The fee-payer account (first account in the message). */
+  feePayer: PublicKey;
+  /** The recent blockhash committed to by this transaction. */
+  blockhash: Blockhash;
+  /** Signatures in signer order (may contain empty Uint8Arrays for missing sigs). */
+  signatures: TransactionSignature[];
+  /** Address lookup tables referenced by the transaction. */
+  addressLookupTables: CompiledAddressLookupTable[];
+  /** Each instruction in the transaction, in order, fully parsed. */
+  instructions: ParsedInstruction[];
+};
+
+/**
+ * Resolves whether an account at a given flat index is a signer and/or
+ * writable, following the Solana account-list layout:
+ *
+ *   [writable signers] [readonly signers]
+ *   [writable static non-signers] [readonly static non-signers]
+ *   [writable LUT accounts] [readonly LUT accounts]
+ *
+ * The header's `numReadonlyUnsignedAccounts` counts only *static* readonly
+ * non-signers, so for v0 transactions the total account count cannot be used
+ * naively — we must derive the static account count from the lookup tables.
+ */
+function resolveAccountMeta(
+  index: number,
+  message: TransactionMessage
+): { isSigner: boolean; isWritable: boolean } {
+  const {
+    numRequiredSignatures,
+    numReadonlySignedAccounts,
+    numReadonlyUnsignedAccounts,
+  } = message.header;
+
+  // Signer accounts occupy the first numRequiredSignatures slots.
+  if (index < numRequiredSignatures) {
+    return {
+      isSigner: true,
+      isWritable: index < numRequiredSignatures - numReadonlySignedAccounts,
+    };
+  }
+
+  // Compute how many accounts come from lookup tables so we can separate them
+  // from the static non-signer accounts.
+  const numLutAccounts = message.addressLookupTables.reduce(
+    (sum, lut) => sum + lut.writableIndexes.length + lut.readonlyIndexes.length,
+    0
+  );
+  const numStaticAccounts = message.accounts.length - numLutAccounts;
+
+  if (index < numStaticAccounts) {
+    // Static non-signer: writable unless in the trailing readonly region.
+    return {
+      isSigner: false,
+      isWritable: index < numStaticAccounts - numReadonlyUnsignedAccounts,
+    };
+  }
+
+  // LUT-resolved account: writable LUT accounts precede readonly LUT accounts.
+  const numLutWritable = message.addressLookupTables.reduce(
+    (sum, lut) => sum + lut.writableIndexes.length,
+    0
+  );
+  return {
+    isSigner: false,
+    isWritable: index - numStaticAccounts < numLutWritable,
+  };
+}
 
 /**
  * Parses a raw instruction into a {@link ParsedInstruction} by looking up
@@ -62,19 +147,21 @@ export type ParsedInstruction = {
  *
  * @param context - A context containing a program repository.
  * @param instruction - The raw instruction to parse.
+ * @param index - The zero-based position of this instruction in its transaction.
  * @returns A fully parsed instruction with program name, instruction name,
  *          deserialized data, and named accounts when available.
  * @category Transaction Parser
  */
 export function parseInstruction(
   context: Pick<Context, 'programs'>,
-  instruction: Instruction
+  instruction: Instruction,
+  index = 0
 ): ParsedInstruction {
   const { programId, keys, data } = instruction;
 
-  // Check if the program is registered in the repository.
   if (!context.programs.has(programId)) {
     return {
+      index,
       programName: 'unknown',
       programId,
       instructionName: 'unknown',
@@ -87,9 +174,9 @@ export function parseInstruction(
   const programName = program.name;
   const instructionDescriptors = program.instructions;
 
-  // If no instruction descriptors are registered, return with known program but unknown instruction.
   if (!instructionDescriptors || instructionDescriptors.length === 0) {
     return {
+      index,
       programName,
       programId,
       instructionName: 'unknown',
@@ -98,16 +185,17 @@ export function parseInstruction(
     };
   }
 
-  // Find matching descriptor by comparing discriminator bytes.
   const descriptor = instructionDescriptors.find((desc) => {
-    if (data.length < desc.discriminator.size) return false;
-    const dataSlice = data.slice(0, desc.discriminator.size);
-    return dataSlice.every((byte, i) => byte === desc.discriminator.bytes[i]);
+    const discSize = desc.discriminator.bytes.length;
+    if (data.length < discSize) return false;
+    return data
+      .subarray(0, discSize)
+      .every((byte, i) => byte === desc.discriminator.bytes[i]);
   });
 
-  // No matching discriminator found.
   if (!descriptor) {
     return {
+      index,
       programName,
       programId,
       instructionName: 'unknown',
@@ -116,16 +204,14 @@ export function parseInstruction(
     };
   }
 
-  // Deserialize instruction data after the discriminator.
-  const dataAfterDiscriminator = data.slice(descriptor.discriminator.size);
-  let parsedData: object;
+  const discSize = descriptor.discriminator.bytes.length;
+  const dataAfterDiscriminator = data.subarray(discSize);
+  let parsedData: Record<string, unknown>;
   try {
-    [parsedData] = descriptor.dataSerializer.deserialize(
-      dataAfterDiscriminator
-    );
+    [parsedData] = descriptor.dataSerializer.deserialize(dataAfterDiscriminator);
   } catch {
-    // If deserialization fails, return raw data.
     return {
+      index,
       programName,
       programId,
       instructionName: descriptor.name,
@@ -134,13 +220,13 @@ export function parseInstruction(
     };
   }
 
-  // Map account names positionally.
-  const accounts: ParsedAccountMeta[] = keys.map((key, index) => ({
+  const accounts: ParsedAccountMeta[] = keys.map((key, i) => ({
     ...key,
-    name: descriptor.accountNames?.[index],
+    name: descriptor.accountNames?.[i],
   }));
 
   return {
+    index,
     programName,
     programId,
     instructionName: descriptor.name,
@@ -150,35 +236,39 @@ export function parseInstruction(
 }
 
 /**
- * Parses all instructions in a transaction by decompiling compiled instructions
- * and running each through {@link parseInstruction}.
+ * Parses a full transaction into a {@link ParsedTransaction}, decompiling
+ * compiled instructions (resolving index references to public keys and
+ * computing signer/writable flags) and running each through
+ * {@link parseInstruction}.
+ *
+ * The returned object includes transaction-level metadata — version, fee
+ * payer, blockhash, signatures, and address lookup tables — in addition to
+ * the parsed instruction list.
  *
  * @category Transaction Parser
  */
 export function parseTransaction(
   context: Pick<Context, 'programs'>,
   transaction: Transaction
-): ParsedInstruction[] {
+): ParsedTransaction {
   const { message } = transaction;
-  return message.instructions.map((compiledIx) => {
-    // Decompile: resolve program ID and account keys from indexes.
+
+  const instructions = message.instructions.map((compiledIx, ixIndex) => {
     const programId = message.accounts[compiledIx.programIndex];
-    const keys = compiledIx.accountIndexes.map((index) => {
-      const pubkey = message.accounts[index];
-      const numSigners = message.header.numRequiredSignatures;
-      const numReadonlySigned = message.header.numReadonlySignedAccounts;
-      const numReadonlyUnsigned = message.header.numReadonlyUnsignedAccounts;
-      const isSigner = index < numSigners;
-      const isWritable = isSigner
-        ? index < numSigners - numReadonlySigned
-        : index < message.accounts.length - numReadonlyUnsigned;
+    const keys = compiledIx.accountIndexes.map((accountIndex) => {
+      const pubkey = message.accounts[accountIndex];
+      const { isSigner, isWritable } = resolveAccountMeta(accountIndex, message);
       return { pubkey, isSigner, isWritable };
     });
-
-    return parseInstruction(context, {
-      programId,
-      keys,
-      data: compiledIx.data,
-    });
+    return parseInstruction(context, { programId, keys, data: compiledIx.data }, ixIndex);
   });
+
+  return {
+    version: message.version,
+    feePayer: message.accounts[0],
+    blockhash: message.blockhash,
+    signatures: [...transaction.signatures],
+    addressLookupTables: [...message.addressLookupTables],
+    instructions,
+  };
 }

--- a/packages/umi/test/TransactionParser.test.ts
+++ b/packages/umi/test/TransactionParser.test.ts
@@ -15,19 +15,17 @@ import {
 } from '../src';
 import { struct, u64 } from '../src/serializers';
 
-test('InstructionDiscriminator type has bytes and size', (t) => {
+test('InstructionDiscriminator type has bytes field', (t) => {
   const discriminator: InstructionDiscriminator = {
     bytes: new Uint8Array([33]),
-    size: 1,
   };
-  t.is(discriminator.size, 1);
   t.deepEqual(discriminator.bytes, new Uint8Array([33]));
 });
 
 test('InstructionDescriptor type has name, discriminator, dataSerializer, and optional accountNames', (t) => {
   const descriptor: InstructionDescriptor = {
     name: 'transfer',
-    discriminator: { bytes: new Uint8Array([2]), size: 1 },
+    discriminator: { bytes: new Uint8Array([2]) },
     dataSerializer: {
       description: 'test',
       fixedSize: 8,
@@ -43,6 +41,7 @@ test('InstructionDescriptor type has name, discriminator, dataSerializer, and op
 
 test('ParsedInstruction type has expected shape', (t) => {
   const parsed: ParsedInstruction = {
+    index: 0,
     programName: 'splToken',
     programId: publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
     instructionName: 'transfer',
@@ -58,6 +57,7 @@ test('ParsedInstruction type has expected shape', (t) => {
   };
   t.is(parsed.programName, 'splToken');
   t.is(parsed.instructionName, 'transfer');
+  t.is(parsed.index, 0);
 });
 
 // Helper: create a minimal program repository for testing.
@@ -111,12 +111,24 @@ test('parseInstruction returns unknown for unregistered program', (t) => {
     ],
     data: new Uint8Array([1, 2, 3]),
   };
-  const result = parseInstruction(context, instruction);
+  const result = parseInstruction(context, instruction, 2);
+  t.is(result.index, 2);
   t.is(result.programName, 'unknown');
   t.is(result.instructionName, 'unknown');
   t.deepEqual(result.data, new Uint8Array([1, 2, 3]));
   t.is(result.accounts.length, 1);
   t.is(result.accounts[0].name, undefined);
+});
+
+test('parseInstruction defaults index to 0', (t) => {
+  const context = { programs: createTestProgramRepository([]) };
+  const instruction: Instruction = {
+    programId: publicKey('11111111111111111111111111111111'),
+    keys: [],
+    data: new Uint8Array([1]),
+  };
+  const result = parseInstruction(context, instruction);
+  t.is(result.index, 0);
 });
 
 test('parseInstruction returns unknown instruction for program with no descriptors', (t) => {
@@ -155,7 +167,7 @@ test('parseInstruction deserializes matching instruction', (t) => {
     instructions: [
       {
         name: 'transfer',
-        discriminator: { bytes: new Uint8Array([3]), size: 1 },
+        discriminator: { bytes: new Uint8Array([3]) },
         dataSerializer,
         accountNames: ['source', 'destination', 'authority'],
       },
@@ -201,7 +213,7 @@ test('parseInstruction returns unknown for non-matching discriminator', (t) => {
     instructions: [
       {
         name: 'transfer',
-        discriminator: { bytes: new Uint8Array([3]), size: 1 },
+        discriminator: { bytes: new Uint8Array([3]) },
         dataSerializer: {
           description: 'test',
           fixedSize: 8,
@@ -238,7 +250,7 @@ test('parseInstruction matches 8-byte Anchor discriminator', (t) => {
     instructions: [
       {
         name: 'initialize',
-        discriminator: { bytes: anchorDiscriminator, size: 8 },
+        discriminator: { bytes: anchorDiscriminator },
         dataSerializer: {
           description: 'initializeData',
           fixedSize: 0,
@@ -275,7 +287,7 @@ test('parseInstruction handles more accounts than accountNames', (t) => {
     instructions: [
       {
         name: 'doStuff',
-        discriminator: { bytes: new Uint8Array([1]), size: 1 },
+        discriminator: { bytes: new Uint8Array([1]) },
         dataSerializer: {
           description: 'test',
           fixedSize: 0,
@@ -321,7 +333,7 @@ test('parseInstruction falls back to raw data on deserialization failure', (t) =
     instructions: [
       {
         name: 'failingIx',
-        discriminator: { bytes: new Uint8Array([1]), size: 1 },
+        discriminator: { bytes: new Uint8Array([1]) },
         dataSerializer: {
           description: 'broken',
           fixedSize: null,
@@ -360,26 +372,80 @@ function createTestTransaction(
     numRequiredSignatures: number;
     numReadonlySignedAccounts: number;
     numReadonlyUnsignedAccounts: number;
+  },
+  options?: {
+    version?: 'legacy' | 0;
+    addressLookupTables?: {
+      publicKey: PublicKey;
+      writableIndexes: number[];
+      readonlyIndexes: number[];
+    }[];
+    signatures?: Uint8Array[];
+    blockhash?: string;
   }
 ): Transaction {
   const message: TransactionMessage = {
-    version: 'legacy',
+    version: options?.version ?? 'legacy',
     header: header ?? {
       numRequiredSignatures: 1,
       numReadonlySignedAccounts: 0,
       numReadonlyUnsignedAccounts: 0,
     },
     accounts,
-    blockhash: 'test-blockhash',
+    blockhash: options?.blockhash ?? 'test-blockhash',
     instructions,
-    addressLookupTables: [],
+    addressLookupTables: options?.addressLookupTables ?? [],
   };
   return {
     message,
     serializedMessage: new Uint8Array(),
-    signatures: [],
+    signatures: options?.signatures ?? [],
   };
 }
+
+test('parseTransaction returns ParsedTransaction with metadata fields', (t) => {
+  const programKey = publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+  const feePayer = publicKey('So11111111111111111111111111111111111111112');
+  const sig = new Uint8Array(64).fill(1);
+  const context = { programs: createTestProgramRepository([]) };
+
+  const transaction = createTestTransaction(
+    [feePayer, programKey],
+    [{ programIndex: 1, accountIndexes: [], data: new Uint8Array([9]) }],
+    { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+    { version: 'legacy', blockhash: 'my-blockhash', signatures: [sig] }
+  );
+
+  const result = parseTransaction(context, transaction);
+  t.is(result.version, 'legacy');
+  t.is(result.feePayer, feePayer);
+  t.is(result.blockhash, 'my-blockhash');
+  t.is(result.signatures.length, 1);
+  t.deepEqual(result.signatures[0], sig);
+  t.deepEqual(result.addressLookupTables, []);
+  t.is(result.instructions.length, 1);
+});
+
+test('parseTransaction assigns sequential indexes to instructions', (t) => {
+  const program1Key = publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
+  const program2Key = publicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ');
+  const acc1 = publicKey('So11111111111111111111111111111111111111112');
+
+  const context = { programs: createTestProgramRepository([]) };
+  const transaction = createTestTransaction(
+    [acc1, program1Key, program2Key],
+    [
+      { programIndex: 1, accountIndexes: [], data: new Uint8Array([1]) },
+      { programIndex: 2, accountIndexes: [], data: new Uint8Array([2]) },
+      { programIndex: 1, accountIndexes: [], data: new Uint8Array([3]) },
+    ]
+  );
+
+  const result = parseTransaction(context, transaction);
+  t.is(result.instructions[0].index, 0);
+  t.is(result.instructions[1].index, 1);
+  t.is(result.instructions[2].index, 2);
+});
 
 test('parseTransaction parses all instructions in a transaction', (t) => {
   const programKey = publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
@@ -392,7 +458,7 @@ test('parseTransaction parses all instructions in a transaction', (t) => {
     instructions: [
       {
         name: 'transfer',
-        discriminator: { bytes: new Uint8Array([3]), size: 1 },
+        discriminator: { bytes: new Uint8Array([3]) },
         dataSerializer: {
           description: 'transferData',
           fixedSize: 8,
@@ -421,14 +487,15 @@ test('parseTransaction parses all instructions in a transaction', (t) => {
   );
 
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 1);
-  t.is(result[0].programName, 'splToken');
-  t.is(result[0].instructionName, 'transfer');
-  t.deepEqual(result[0].data, { amount: 42n });
-  t.is(result[0].accounts[0].pubkey, acc1);
-  t.is(result[0].accounts[0].name, 'source');
-  t.is(result[0].accounts[1].pubkey, acc2);
-  t.is(result[0].accounts[1].name, 'destination');
+  t.is(result.instructions.length, 1);
+  t.is(result.instructions[0].index, 0);
+  t.is(result.instructions[0].programName, 'splToken');
+  t.is(result.instructions[0].instructionName, 'transfer');
+  t.deepEqual(result.instructions[0].data, { amount: 42n });
+  t.is(result.instructions[0].accounts[0].pubkey, acc1);
+  t.is(result.instructions[0].accounts[0].name, 'source');
+  t.is(result.instructions[0].accounts[1].pubkey, acc2);
+  t.is(result.instructions[0].accounts[1].name, 'destination');
 });
 
 test('parseTransaction handles multiple instructions', (t) => {
@@ -442,7 +509,7 @@ test('parseTransaction handles multiple instructions', (t) => {
     instructions: [
       {
         name: 'ix1',
-        discriminator: { bytes: new Uint8Array([1]), size: 1 },
+        discriminator: { bytes: new Uint8Array([1]) },
         dataSerializer: {
           description: 'test',
           fixedSize: 0,
@@ -473,18 +540,129 @@ test('parseTransaction handles multiple instructions', (t) => {
   );
 
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 2);
-  t.is(result[0].programName, 'program1');
-  t.is(result[0].instructionName, 'ix1');
-  t.is(result[1].programName, 'program2');
-  t.is(result[1].instructionName, 'unknown');
+  t.is(result.instructions.length, 2);
+  t.is(result.instructions[0].programName, 'program1');
+  t.is(result.instructions[0].instructionName, 'ix1');
+  t.is(result.instructions[1].programName, 'program2');
+  t.is(result.instructions[1].instructionName, 'unknown');
 });
 
 test('parseTransaction handles empty transaction', (t) => {
   const context = { programs: createTestProgramRepository([]) };
   const transaction = createTestTransaction([], []);
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 0);
+  t.is(result.instructions.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// isWritable / isSigner derivation tests
+// ---------------------------------------------------------------------------
+
+test('parseTransaction correctly derives isSigner and isWritable for legacy accounts', (t) => {
+  // Layout: [writableSigner(0), readonlySigner(1), writableNonSigner(2), readonlyNonSigner(3), programKey(4)]
+  // numRequired=2, numReadonlySigned=1, numReadonlyUnsigned=2
+  //   Writable signers: [0]  (numRequired - numReadonlySigned = 1)
+  //   Readonly signers: [1]
+  //   Writable non-signers: [2]  (numStaticAccounts(5) - numReadonlyUnsigned(2) = 3 → indices < 3)
+  //   Readonly non-signers: [3, 4]
+  const writableSigner = publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu');
+  const readonlySigner = publicKey('29S9SK4gMpWrLHGBgrRJTSkNdfuZjq6Pqxv3tesuAx8s');
+  const writableNonSigner = publicKey('So11111111111111111111111111111111111111112');
+  const readonlyNonSigner = publicKey('SysvarRent111111111111111111111111111111111');
+  const programKey = publicKey('11111111111111111111111111111111');
+
+  const context = { programs: createTestProgramRepository([]) };
+  const transaction = createTestTransaction(
+    [writableSigner, readonlySigner, writableNonSigner, readonlyNonSigner, programKey],
+    [
+      {
+        programIndex: 4,
+        accountIndexes: [0, 1, 2, 3],
+        data: new Uint8Array([0]),
+      },
+    ],
+    { numRequiredSignatures: 2, numReadonlySignedAccounts: 1, numReadonlyUnsignedAccounts: 2 }
+  );
+
+  const result = parseTransaction(context, transaction);
+  const accounts = result.instructions[0].accounts;
+  t.true(accounts[0].isSigner);
+  t.true(accounts[0].isWritable);
+  t.true(accounts[1].isSigner);
+  t.false(accounts[1].isWritable);
+  t.false(accounts[2].isSigner);
+  t.true(accounts[2].isWritable);
+  t.false(accounts[3].isSigner);
+  t.false(accounts[3].isWritable);
+});
+
+test('parseTransaction correctly derives isWritable for v0 address lookup table accounts', (t) => {
+  // Static accounts: [signer(w), staticNonSigner(w), staticNonSigner(r), program]
+  //   numRequired=1, numReadonlySigned=0, numReadonlyUnsigned=1 (covers staticNonSigner(r) only)
+  // LUT appends: [lutWritable1, lutWritable2, lutReadonly]
+  // Flat index layout: 0=signer(w), 1=staticNonSigner(w), 2=staticNonSigner(r), 3=program,
+  //                    4=lutWritable1, 5=lutWritable2, 6=lutReadonly
+  const signerKey = publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu');
+  const staticWritable = publicKey('29S9SK4gMpWrLHGBgrRJTSkNdfuZjq6Pqxv3tesuAx8s');
+  const staticReadonly = publicKey('SysvarRent111111111111111111111111111111111');
+  const programKey = publicKey('11111111111111111111111111111111');
+  const lutKey = publicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+  const lutWritable1 = publicKey('So11111111111111111111111111111111111111112');
+  const lutWritable2 = publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+  const lutReadonly = publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
+
+  const context = { programs: createTestProgramRepository([]) };
+  const transaction = createTestTransaction(
+    // All 7 accounts flat (static first, then LUT-resolved in order)
+    [signerKey, staticWritable, staticReadonly, programKey, lutWritable1, lutWritable2, lutReadonly],
+    [
+      {
+        programIndex: 3,
+        accountIndexes: [0, 1, 2, 4, 5, 6],
+        data: new Uint8Array([0]),
+      },
+    ],
+    // numReadonlyUnsigned=2 → static non-signers at indices [1,2,3]: last 2 are readonly → index 1 writable, indices 2,3 readonly
+    { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 2 },
+    {
+      version: 0,
+      addressLookupTables: [
+        { publicKey: lutKey, writableIndexes: [0, 1], readonlyIndexes: [2] },
+      ],
+    }
+  );
+
+  const result = parseTransaction(context, transaction);
+  const accounts = result.instructions[0].accounts;
+
+  // index 0: signer, writable
+  t.true(accounts[0].isSigner);
+  t.true(accounts[0].isWritable);
+
+  // index 1: static non-signer, writable
+  t.false(accounts[1].isSigner);
+  t.true(accounts[1].isWritable);
+
+  // index 2: static non-signer, readonly
+  t.false(accounts[2].isSigner);
+  t.false(accounts[2].isWritable);
+
+  // index 4: first LUT account — writable
+  t.false(accounts[3].isSigner);
+  t.true(accounts[3].isWritable);
+
+  // index 5: second LUT account — writable
+  t.false(accounts[4].isSigner);
+  t.true(accounts[4].isWritable);
+
+  // index 6: third LUT account — readonly
+  t.false(accounts[5].isSigner);
+  t.false(accounts[5].isWritable);
+
+  // ParsedTransaction also carries the LUT metadata
+  t.is(result.version, 0);
+  t.is(result.addressLookupTables.length, 1);
+  t.is(result.addressLookupTables[0].publicKey, lutKey);
 });
 
 // ---------------------------------------------------------------------------
@@ -535,7 +713,7 @@ const MAINNET_ACCOUNTS: PublicKey[] = [
   publicKey('C2aFPdENg4A2HQsmrd5rTw5TaYBX5Ku887cWjbFKtZpw'), // 18
   publicKey('ComputeBudget111111111111111111111111111111'), // 19
   publicKey('GS4CU59F31iL7aR2Q8zVS8DRrcRnXX1yjQ66TqNVQnaR'), // 20
-  publicKey('jitodontfront111111111116111111111111165521'), // 21 - not valid base58
+  publicKey('jitodontfront111111111116111111111111165521'), // 21
   publicKey('pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA'), // 22
   publicKey('pfeeUxB6jkeY1Hxd7CsFCAjcbHA9rWtchMGdZ6VojVZ'), // 23
   publicKey('So11111111111111111111111111111111111111112'), // 24
@@ -562,7 +740,6 @@ test('parseTransaction parses real mainnet System Program transfers', (t) => {
         // System Program Transfer has u32 discriminator = 2
         discriminator: {
           bytes: new Uint8Array([2, 0, 0, 0]),
-          size: 4,
         },
         dataSerializer: lamportsSerializer,
         accountNames: ['from', 'to'],
@@ -599,26 +776,32 @@ test('parseTransaction parses real mainnet System Program transfers', (t) => {
   );
 
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 3);
+  t.is(result.instructions.length, 3);
+
+  // Fee payer is always accounts[0]
+  t.is(result.feePayer, MAINNET_ACCOUNTS[0]);
 
   // First transfer: 499_550_001 lamports
-  t.is(result[0].programName, 'systemProgram');
-  t.is(result[0].instructionName, 'transfer');
-  t.deepEqual(result[0].data, { lamports: 499550001n });
-  t.is(result[0].accounts[0].name, 'from');
-  t.is(result[0].accounts[0].pubkey, MAINNET_ACCOUNTS[0]);
-  t.is(result[0].accounts[1].name, 'to');
-  t.is(result[0].accounts[1].pubkey, MAINNET_ACCOUNTS[6]);
+  t.is(result.instructions[0].index, 0);
+  t.is(result.instructions[0].programName, 'systemProgram');
+  t.is(result.instructions[0].instructionName, 'transfer');
+  t.deepEqual(result.instructions[0].data, { lamports: 499550001n });
+  t.is(result.instructions[0].accounts[0].name, 'from');
+  t.is(result.instructions[0].accounts[0].pubkey, MAINNET_ACCOUNTS[0]);
+  t.is(result.instructions[0].accounts[1].name, 'to');
+  t.is(result.instructions[0].accounts[1].pubkey, MAINNET_ACCOUNTS[6]);
 
   // Second transfer: 5_000_000 lamports
-  t.is(result[1].instructionName, 'transfer');
-  t.deepEqual(result[1].data, { lamports: 5000000n });
-  t.is(result[1].accounts[1].pubkey, MAINNET_ACCOUNTS[8]);
+  t.is(result.instructions[1].index, 1);
+  t.is(result.instructions[1].instructionName, 'transfer');
+  t.deepEqual(result.instructions[1].data, { lamports: 5000000n });
+  t.is(result.instructions[1].accounts[1].pubkey, MAINNET_ACCOUNTS[8]);
 
   // Third transfer: 500_000 lamports
-  t.is(result[2].instructionName, 'transfer');
-  t.deepEqual(result[2].data, { lamports: 500000n });
-  t.is(result[2].accounts[1].pubkey, MAINNET_ACCOUNTS[3]);
+  t.is(result.instructions[2].index, 2);
+  t.is(result.instructions[2].instructionName, 'transfer');
+  t.deepEqual(result.instructions[2].data, { lamports: 500000n });
+  t.is(result.instructions[2].accounts[1].pubkey, MAINNET_ACCOUNTS[3]);
 });
 
 test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
@@ -629,7 +812,7 @@ test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
       {
         name: 'closeAccount',
         // SPL Token CloseAccount = u8 discriminator 9, no additional data
-        discriminator: { bytes: new Uint8Array([9]), size: 1 },
+        discriminator: { bytes: new Uint8Array([9]) },
         dataSerializer: {
           description: 'closeAccountData',
           fixedSize: 0,
@@ -662,16 +845,16 @@ test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
   );
 
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 1);
-  t.is(result[0].programName, 'splToken');
-  t.is(result[0].instructionName, 'closeAccount');
-  t.deepEqual(result[0].data, {});
-  t.is(result[0].accounts[0].name, 'account');
-  t.is(result[0].accounts[0].pubkey, MAINNET_ACCOUNTS[6]);
-  t.is(result[0].accounts[1].name, 'destination');
-  t.is(result[0].accounts[1].pubkey, MAINNET_ACCOUNTS[0]);
-  t.is(result[0].accounts[2].name, 'owner');
-  t.is(result[0].accounts[2].pubkey, MAINNET_ACCOUNTS[0]);
+  t.is(result.instructions.length, 1);
+  t.is(result.instructions[0].programName, 'splToken');
+  t.is(result.instructions[0].instructionName, 'closeAccount');
+  t.deepEqual(result.instructions[0].data, {});
+  t.is(result.instructions[0].accounts[0].name, 'account');
+  t.is(result.instructions[0].accounts[0].pubkey, MAINNET_ACCOUNTS[6]);
+  t.is(result.instructions[0].accounts[1].name, 'destination');
+  t.is(result.instructions[0].accounts[1].pubkey, MAINNET_ACCOUNTS[0]);
+  t.is(result.instructions[0].accounts[2].name, 'owner');
+  t.is(result.instructions[0].accounts[2].pubkey, MAINNET_ACCOUNTS[0]);
 });
 
 test('parseTransaction handles mix of known and unknown programs from real mainnet data', (t) => {
@@ -681,7 +864,7 @@ test('parseTransaction handles mix of known and unknown programs from real mainn
     instructions: [
       {
         name: 'transfer',
-        discriminator: { bytes: new Uint8Array([2, 0, 0, 0]), size: 4 },
+        discriminator: { bytes: new Uint8Array([2, 0, 0, 0]) },
         dataSerializer: struct([['lamports', u64()]]),
         accountNames: ['from', 'to'],
       },
@@ -717,20 +900,20 @@ test('parseTransaction handles mix of known and unknown programs from real mainn
   );
 
   const result = parseTransaction(context, transaction);
-  t.is(result.length, 3);
+  t.is(result.instructions.length, 3);
 
   // Known: System Program Transfer
-  t.is(result[0].programName, 'systemProgram');
-  t.is(result[0].instructionName, 'transfer');
-  t.deepEqual(result[0].data, { lamports: 499550001n });
+  t.is(result.instructions[0].programName, 'systemProgram');
+  t.is(result.instructions[0].instructionName, 'transfer');
+  t.deepEqual(result.instructions[0].data, { lamports: 499550001n });
 
   // Unknown: SPL Token (not registered)
-  t.is(result[1].programName, 'unknown');
-  t.is(result[1].instructionName, 'unknown');
-  t.deepEqual(result[1].data, new Uint8Array([9]));
+  t.is(result.instructions[1].programName, 'unknown');
+  t.is(result.instructions[1].instructionName, 'unknown');
+  t.deepEqual(result.instructions[1].data, new Uint8Array([9]));
 
   // Unknown: ComputeBudget (not registered)
-  t.is(result[2].programName, 'unknown');
-  t.is(result[2].instructionName, 'unknown');
-  t.deepEqual(result[2].data, new Uint8Array([2, 166, 126, 3, 0]));
+  t.is(result.instructions[2].programName, 'unknown');
+  t.is(result.instructions[2].instructionName, 'unknown');
+  t.deepEqual(result.instructions[2].data, new Uint8Array([2, 166, 126, 3, 0]));
 });


### PR DESCRIPTION
## Summary
This PR refactors the transaction parser to return a structured `ParsedTransaction` object containing transaction-level metadata alongside parsed instructions, rather than a flat array of instructions. It also removes the `size` field from `InstructionDiscriminator` and adds instruction indexing throughout.

## Key Changes

- **New `ParsedTransaction` type**: Returns transaction metadata (version, feePayer, blockhash, signatures, addressLookupTables) alongside instructions
- **Instruction indexing**: Added `index` field to `ParsedInstruction` to track zero-based position within transaction; `parseInstruction()` now accepts optional `index` parameter (defaults to 0)
- **Simplified `InstructionDiscriminator`**: Removed `size` field; discriminator size is now inferred from `bytes.length`
- **Account metadata resolution**: Implemented `resolveAccountMeta()` function to correctly derive `isSigner` and `isWritable` flags for both legacy and v0 transactions, accounting for address lookup tables
- **Enhanced test helper**: Updated `createTestTransaction()` to support v0 transactions with address lookup tables, signatures, and custom blockhash
- **Comprehensive test coverage**: Added tests for:
  - Sequential instruction indexing
  - Legacy account metadata derivation
  - v0 address lookup table account metadata derivation
  - Transaction-level metadata preservation

## Implementation Details

- The `resolveAccountMeta()` function properly handles the Solana account layout: writable signers, readonly signers, writable static non-signers, readonly static non-signers, writable LUT accounts, and readonly LUT accounts
- For v0 transactions, the function correctly separates static accounts from LUT-resolved accounts by computing the total LUT account count
- All existing tests updated to use `result.instructions[i]` instead of `result[i]` and to verify the new `index` field
- Discriminator matching now uses `subarray()` instead of `slice()` for consistency

https://claude.ai/code/session_01JrMxDcpWQhrzfARj9eQLon