### PR TITLE
fix(transaction-parser): correct v0 LUT handling, surface meta + inner instructions

### DIFF
--- a/.changeset/transaction-parser-fixes.md
+++ b/.changeset/transaction-parser-fixes.md
@@ -1,0 +1,12 @@
+---
+'@metaplex-foundation/umi': minor
+---
+
+Transaction parser fixes and completeness improvements:
+
+- Fix `parseTransaction` for v0 transactions that use address lookup tables. The previous implementation derived `numStaticAccounts` by subtracting LUT counts from `message.accounts.length`, but `message.accounts` only ever contains static account keys, so the math was wrong: static readonly accounts were reported as writable, LUT-resolved indices returned `pubkey: undefined`, and LUT writability flags were inverted. `resolveAccountMeta` now treats `message.accounts.length` as the static count directly.
+- `parseTransaction` now accepts `TransactionWithMeta` and an optional `loadedAddresses` option. When LUT-resolved accounts are referenced, the parser pulls pubkeys from `meta.loadedAddresses` (if present) or `options.loadedAddresses`, and throws a clear error if neither is supplied. `meta.innerInstructions` are also decompiled and parsed as `ParsedInstruction[]`.
+- `ParsedTransaction` now exposes the message header, the full static account list, the resolved `loadedAddresses`, the post-execution `meta`, and parsed `innerInstructions`.
+- `ParsedInstruction` gained a `status` field (`'parsed' | 'unknown-program' | 'no-descriptors' | 'no-discriminator-match' | 'deserialize-failed'`), a `rawData: Uint8Array` always populated alongside the parsed `data`, and a `remainingBytes: Uint8Array` surfacing any bytes the data serializer did not consume.
+- `parseInstruction` now matches descriptors longest-discriminator-first, so a short prefix (e.g. SPL Token `[3]`) registered before a longer one (e.g. an Anchor 8-byte) no longer shadows it.
+- `parseInstruction` and `parseTransaction` accept an optional `clusterFilter`, defaulting to `'*'` so the parser is decoupled from the umi instance's current cluster.

--- a/packages/umi/src/TransactionParser.ts
+++ b/packages/umi/src/TransactionParser.ts
@@ -1,14 +1,20 @@
 import type { PublicKey } from '@metaplex-foundation/umi-public-keys';
 import type { Serializer } from '@metaplex-foundation/umi-serializers';
+import type { ClusterFilter } from './Cluster';
 import type { Context } from './Context';
 import type { AccountMeta, Instruction } from './Instruction';
 import type {
   Blockhash,
   CompiledAddressLookupTable,
+  CompiledInstruction,
   Transaction,
   TransactionMessage,
+  TransactionMessageHeader,
+  TransactionMeta,
+  TransactionMetaLoadedAddresses,
   TransactionSignature,
   TransactionVersion,
+  TransactionWithMeta,
 } from './Transaction';
 
 /**
@@ -46,6 +52,22 @@ export type ParsedAccountMeta = AccountMeta & {
 };
 
 /**
+ * The outcome of parsing a single instruction.
+ * @category Transaction Parser
+ */
+export type ParseStatus =
+  /** The instruction was matched to a descriptor and its data was deserialized. */
+  | 'parsed'
+  /** The program is not registered in the repository. */
+  | 'unknown-program'
+  /** The program is registered but has no instruction descriptors. */
+  | 'no-descriptors'
+  /** The program is registered with descriptors but none matched the discriminator. */
+  | 'no-discriminator-match'
+  /** A descriptor matched but its data serializer threw while deserializing. */
+  | 'deserialize-failed';
+
+/**
  * A fully parsed instruction from a transaction.
  * @category Transaction Parser
  */
@@ -58,10 +80,32 @@ export type ParsedInstruction = {
   programId: PublicKey;
   /** The name of the instruction, or 'unknown'. */
   instructionName: string;
-  /** The deserialized instruction data, or the raw Uint8Array if unknown. */
-  data: Record<string, unknown> | Uint8Array;
+  /** Indicates how far parsing progressed and why it stopped. */
+  status: ParseStatus;
+  /** The deserialized instruction fields when {@link status} is `'parsed'`,
+   *  otherwise `null`. Use {@link rawData} to access the original bytes. */
+  data: Record<string, unknown> | null;
+  /** The original raw instruction bytes, including the discriminator. Always
+   *  populated regardless of {@link status}. */
+  rawData: Uint8Array;
+  /** Bytes that the data serializer did not consume after the discriminator.
+   *  An empty array when the serializer fully consumed the buffer or when no
+   *  descriptor matched. A non-empty value is typically a sign of a malformed
+   *  instruction or a descriptor that disagrees with the on-chain ABI. */
+  remainingBytes: Uint8Array;
   /** The accounts used by the instruction, with optional names. */
   accounts: ParsedAccountMeta[];
+};
+
+/**
+ * A group of CPI inner instructions parsed from a transaction's metadata.
+ * @category Transaction Parser
+ */
+export type ParsedInnerInstructions = {
+  /** The index of the outer instruction these inner instructions belong to. */
+  index: number;
+  /** The parsed inner instructions, in order. */
+  instructions: ParsedInstruction[];
 };
 
 /**
@@ -76,13 +120,65 @@ export type ParsedTransaction = {
   feePayer: PublicKey;
   /** The recent blockhash committed to by this transaction. */
   blockhash: Blockhash;
+  /** The message header (signer counts and readonly counts). */
+  header: TransactionMessageHeader;
+  /** The static account keys carried directly in the transaction message. */
+  staticAccounts: PublicKey[];
+  /** Resolved LUT addresses, when available either from `meta.loadedAddresses`
+   *  or supplied via `parseTransaction` options. `null` for legacy transactions
+   *  or when no LUT data was provided. */
+  loadedAddresses: TransactionMetaLoadedAddresses | null;
   /** Signatures in signer order (may contain empty Uint8Arrays for missing sigs). */
   signatures: TransactionSignature[];
-  /** Address lookup tables referenced by the transaction. */
+  /** Address lookup tables referenced by the transaction, in compiled form. */
   addressLookupTables: CompiledAddressLookupTable[];
-  /** Each instruction in the transaction, in order, fully parsed. */
+  /** Each top-level instruction in the transaction, in order, fully parsed. */
   instructions: ParsedInstruction[];
+  /** Parsed inner (CPI) instructions when the transaction has executed
+   *  metadata; `null` otherwise. */
+  innerInstructions: ParsedInnerInstructions[] | null;
+  /** Post-execution metadata when the input was a {@link TransactionWithMeta},
+   *  `null` otherwise. */
+  meta: TransactionMeta | null;
 };
+
+/**
+ * Options for {@link parseInstruction}.
+ * @category Transaction Parser
+ */
+export type ParseInstructionOptions = {
+  /** Cluster filter used to look up the program in the repository. Defaults
+   *  to `'*'` so the parser is decoupled from the umi instance's current
+   *  cluster — this lets you parse mainnet transactions against a devnet-
+   *  configured umi without having to register the program twice. */
+  clusterFilter?: ClusterFilter;
+};
+
+/**
+ * Options for {@link parseTransaction}.
+ * @category Transaction Parser
+ */
+export type ParseTransactionOptions = {
+  /** Resolved addresses from address lookup tables. If omitted and the
+   *  transaction is a {@link TransactionWithMeta} carrying
+   *  `meta.loadedAddresses`, those are used. Required for v0 transactions
+   *  whose instructions reference LUT-loaded accounts. */
+  loadedAddresses?: TransactionMetaLoadedAddresses;
+  /** Cluster filter used to look up programs. Defaults to `'*'`. */
+  clusterFilter?: ClusterFilter;
+};
+
+const EMPTY_BYTES = new Uint8Array(0);
+
+function isTransactionWithMeta(
+  tx: Transaction | TransactionWithMeta
+): tx is TransactionWithMeta {
+  return (
+    'meta' in tx &&
+    (tx as TransactionWithMeta).meta !== null &&
+    (tx as TransactionWithMeta).meta !== undefined
+  );
+}
 
 /**
  * Resolves whether an account at a given flat index is a signer and/or
@@ -92,9 +188,9 @@ export type ParsedTransaction = {
  *   [writable static non-signers] [readonly static non-signers]
  *   [writable LUT accounts] [readonly LUT accounts]
  *
- * The header's `numReadonlyUnsignedAccounts` counts only *static* readonly
- * non-signers, so for v0 transactions the total account count cannot be used
- * naively — we must derive the static account count from the lookup tables.
+ * `message.accounts` always holds *only* the static account keys (matching
+ * `staticAccountKeys` from web3.js); LUT-resolved accounts live beyond
+ * `message.accounts.length` in the flat index space.
  */
 function resolveAccountMeta(
   index: number,
@@ -105,8 +201,8 @@ function resolveAccountMeta(
     numReadonlySignedAccounts,
     numReadonlyUnsignedAccounts,
   } = message.header;
+  const numStaticAccounts = message.accounts.length;
 
-  // Signer accounts occupy the first numRequiredSignatures slots.
   if (index < numRequiredSignatures) {
     return {
       isSigner: true,
@@ -114,23 +210,14 @@ function resolveAccountMeta(
     };
   }
 
-  // Compute how many accounts come from lookup tables so we can separate them
-  // from the static non-signer accounts.
-  const numLutAccounts = message.addressLookupTables.reduce(
-    (sum, lut) => sum + lut.writableIndexes.length + lut.readonlyIndexes.length,
-    0
-  );
-  const numStaticAccounts = message.accounts.length - numLutAccounts;
-
   if (index < numStaticAccounts) {
-    // Static non-signer: writable unless in the trailing readonly region.
     return {
       isSigner: false,
       isWritable: index < numStaticAccounts - numReadonlyUnsignedAccounts,
     };
   }
 
-  // LUT-resolved account: writable LUT accounts precede readonly LUT accounts.
+  // LUT-resolved account: writable LUT entries precede readonly LUT entries.
   const numLutWritable = message.addressLookupTables.reduce(
     (sum, lut) => sum + lut.writableIndexes.length,
     0
@@ -141,56 +228,111 @@ function resolveAccountMeta(
   };
 }
 
+function resolvePubkey(
+  index: number,
+  message: TransactionMessage,
+  loadedAddresses: TransactionMetaLoadedAddresses | null
+): PublicKey {
+  const numStaticAccounts = message.accounts.length;
+  if (index < numStaticAccounts) {
+    return message.accounts[index];
+  }
+
+  if (!loadedAddresses) {
+    throw new Error(
+      `Cannot resolve account at flat index ${index}: the transaction uses ` +
+        `address lookup tables but no loadedAddresses were supplied. Pass ` +
+        `\`options.loadedAddresses\` or call \`parseTransaction\` with a ` +
+        `TransactionWithMeta whose meta carries loadedAddresses.`
+    );
+  }
+
+  const lutIndex = index - numStaticAccounts;
+  const numLutWritable = loadedAddresses.writable.length;
+  if (lutIndex < numLutWritable) {
+    return loadedAddresses.writable[lutIndex];
+  }
+
+  const readonlyIndex = lutIndex - numLutWritable;
+  if (readonlyIndex >= loadedAddresses.readonly.length) {
+    throw new Error(
+      `Cannot resolve account at flat index ${index}: out of range for the ` +
+        `provided loadedAddresses ` +
+        `(writable=${numLutWritable}, readonly=${loadedAddresses.readonly.length}).`
+    );
+  }
+  return loadedAddresses.readonly[readonlyIndex];
+}
+
 /**
  * Parses a raw instruction into a {@link ParsedInstruction} by looking up
  * the program and matching the instruction discriminator.
  *
+ * Descriptor matching prefers the longest discriminator first so a one-byte
+ * discriminator (e.g. SPL Token `[3]`) registered alongside a longer one
+ * (e.g. an Anchor 8-byte) cannot shadow it.
+ *
  * @param context - A context containing a program repository.
  * @param instruction - The raw instruction to parse.
  * @param index - The zero-based position of this instruction in its transaction.
- * @returns A fully parsed instruction with program name, instruction name,
- *          deserialized data, and named accounts when available.
+ * @param options - Optional parser options (e.g. cluster filter).
  * @category Transaction Parser
  */
 export function parseInstruction(
   context: Pick<Context, 'programs'>,
   instruction: Instruction,
-  index = 0
+  index = 0,
+  options: ParseInstructionOptions = {}
 ): ParsedInstruction {
   const { programId, keys, data } = instruction;
+  const clusterFilter: ClusterFilter = options.clusterFilter ?? '*';
+  const baseAccounts: ParsedAccountMeta[] = keys.map((key) => ({ ...key }));
 
-  if (!context.programs.has(programId)) {
+  if (!context.programs.has(programId, clusterFilter)) {
     return {
       index,
       programName: 'unknown',
       programId,
       instructionName: 'unknown',
-      data,
-      accounts: keys.map((key) => ({ ...key })),
+      status: 'unknown-program',
+      data: null,
+      rawData: data,
+      remainingBytes: EMPTY_BYTES,
+      accounts: baseAccounts,
     };
   }
 
-  const program = context.programs.get(programId);
+  const program = context.programs.get(programId, clusterFilter);
   const programName = program.name;
-  const instructionDescriptors = program.instructions;
+  const descriptors = program.instructions;
 
-  if (!instructionDescriptors || instructionDescriptors.length === 0) {
+  if (!descriptors || descriptors.length === 0) {
     return {
       index,
       programName,
       programId,
       instructionName: 'unknown',
-      data,
-      accounts: keys.map((key) => ({ ...key })),
+      status: 'no-descriptors',
+      data: null,
+      rawData: data,
+      remainingBytes: EMPTY_BYTES,
+      accounts: baseAccounts,
     };
   }
 
-  const descriptor = instructionDescriptors.find((desc) => {
+  // Match the longest discriminator first so prefix overlaps don't shadow
+  // more specific descriptors.
+  const orderedDescriptors = [...descriptors].sort(
+    (a, b) => b.discriminator.bytes.length - a.discriminator.bytes.length
+  );
+
+  const descriptor = orderedDescriptors.find((desc) => {
     const discSize = desc.discriminator.bytes.length;
     if (data.length < discSize) return false;
-    return data
-      .subarray(0, discSize)
-      .every((byte, i) => byte === desc.discriminator.bytes[i]);
+    for (let i = 0; i < discSize; i += 1) {
+      if (data[i] !== desc.discriminator.bytes[i]) return false;
+    }
+    return true;
   });
 
   if (!descriptor) {
@@ -199,16 +341,21 @@ export function parseInstruction(
       programName,
       programId,
       instructionName: 'unknown',
-      data,
-      accounts: keys.map((key) => ({ ...key })),
+      status: 'no-discriminator-match',
+      data: null,
+      rawData: data,
+      remainingBytes: EMPTY_BYTES,
+      accounts: baseAccounts,
     };
   }
 
   const discSize = descriptor.discriminator.bytes.length;
   const dataAfterDiscriminator = data.subarray(discSize);
+
   let parsedData: Record<string, unknown>;
+  let consumedOffset: number;
   try {
-    [parsedData] = descriptor.dataSerializer.deserialize(
+    [parsedData, consumedOffset] = descriptor.dataSerializer.deserialize(
       dataAfterDiscriminator
     );
   } catch {
@@ -217,11 +364,15 @@ export function parseInstruction(
       programName,
       programId,
       instructionName: descriptor.name,
-      data,
-      accounts: keys.map((key) => ({ ...key })),
+      status: 'deserialize-failed',
+      data: null,
+      rawData: data,
+      remainingBytes: EMPTY_BYTES,
+      accounts: baseAccounts,
     };
   }
 
+  const remainingBytes = dataAfterDiscriminator.subarray(consumedOffset);
   const accounts: ParsedAccountMeta[] = keys.map((key, i) => ({
     ...key,
     name: descriptor.accountNames?.[i],
@@ -232,7 +383,10 @@ export function parseInstruction(
     programName,
     programId,
     instructionName: descriptor.name,
+    status: 'parsed',
     data: parsedData,
+    rawData: data,
+    remainingBytes,
     accounts,
   };
 }
@@ -243,41 +397,71 @@ export function parseInstruction(
  * computing signer/writable flags) and running each through
  * {@link parseInstruction}.
  *
- * The returned object includes transaction-level metadata — version, fee
- * payer, blockhash, signatures, and address lookup tables — in addition to
- * the parsed instruction list.
+ * Accepts either a {@link Transaction} or a {@link TransactionWithMeta}. When
+ * given a transaction with meta, post-execution metadata is surfaced on the
+ * returned {@link ParsedTransaction.meta}, LUT-resolved pubkeys are taken
+ * from `meta.loadedAddresses`, and `meta.innerInstructions` are decompiled
+ * into {@link ParsedTransaction.innerInstructions}.
+ *
+ * For v0 transactions whose instructions reference LUT-resolved accounts
+ * without meta, supply `options.loadedAddresses` so the parser can resolve
+ * pubkeys; otherwise the parser throws on the first LUT reference.
  *
  * @category Transaction Parser
  */
 export function parseTransaction(
   context: Pick<Context, 'programs'>,
-  transaction: Transaction
+  transaction: Transaction | TransactionWithMeta,
+  options: ParseTransactionOptions = {}
 ): ParsedTransaction {
   const { message } = transaction;
+  const meta = isTransactionWithMeta(transaction) ? transaction.meta : null;
+  const loadedAddresses =
+    options.loadedAddresses ?? meta?.loadedAddresses ?? null;
+  const clusterFilter: ClusterFilter = options.clusterFilter ?? '*';
 
-  const instructions = message.instructions.map((compiledIx, ixIndex) => {
-    const programId = message.accounts[compiledIx.programIndex];
-    const keys = compiledIx.accountIndexes.map((accountIndex) => {
-      const pubkey = message.accounts[accountIndex];
-      const { isSigner, isWritable } = resolveAccountMeta(
-        accountIndex,
-        message
-      );
-      return { pubkey, isSigner, isWritable };
-    });
+  const decompileInstruction = (
+    compiledIx: CompiledInstruction,
+    ixIndex: number
+  ): ParsedInstruction => {
+    const programId = resolvePubkey(
+      compiledIx.programIndex,
+      message,
+      loadedAddresses
+    );
+    const keys: AccountMeta[] = compiledIx.accountIndexes.map((accIndex) => ({
+      pubkey: resolvePubkey(accIndex, message, loadedAddresses),
+      ...resolveAccountMeta(accIndex, message),
+    }));
     return parseInstruction(
       context,
       { programId, keys, data: compiledIx.data },
-      ixIndex
+      ixIndex,
+      { clusterFilter }
     );
-  });
+  };
+
+  const instructions = message.instructions.map(decompileInstruction);
+
+  const innerInstructions: ParsedInnerInstructions[] | null =
+    meta?.innerInstructions != null
+      ? meta.innerInstructions.map((inner) => ({
+          index: inner.index,
+          instructions: inner.instructions.map(decompileInstruction),
+        }))
+      : null;
 
   return {
     version: message.version,
     feePayer: message.accounts[0],
     blockhash: message.blockhash,
+    header: message.header,
+    staticAccounts: [...message.accounts],
+    loadedAddresses,
     signatures: [...transaction.signatures],
     addressLookupTables: [...message.addressLookupTables],
     instructions,
+    innerInstructions,
+    meta,
   };
 }

--- a/packages/umi/test/TransactionParser.test.ts
+++ b/packages/umi/test/TransactionParser.test.ts
@@ -12,6 +12,9 @@ import {
   Program,
   Transaction,
   TransactionMessage,
+  TransactionMeta,
+  TransactionWithMeta,
+  lamports,
 } from '../src';
 import { struct, u64 } from '../src/serializers';
 
@@ -45,7 +48,10 @@ test('ParsedInstruction type has expected shape', (t) => {
     programName: 'splToken',
     programId: publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
     instructionName: 'transfer',
+    status: 'parsed',
     data: { amount: 100n },
+    rawData: new Uint8Array([3, 0, 0, 0, 0, 0, 0, 0, 100]),
+    remainingBytes: new Uint8Array(),
     accounts: [
       {
         pubkey: publicKey('11111111111111111111111111111111'),
@@ -58,6 +64,7 @@ test('ParsedInstruction type has expected shape', (t) => {
   t.is(parsed.programName, 'splToken');
   t.is(parsed.instructionName, 'transfer');
   t.is(parsed.index, 0);
+  t.is(parsed.status, 'parsed');
 });
 
 // Helper: create a minimal program repository for testing.
@@ -96,7 +103,7 @@ function createTestProgram(
   };
 }
 
-test('parseInstruction returns unknown for unregistered program', (t) => {
+test('parseInstruction returns unknown-program for unregistered program', (t) => {
   const context = {
     programs: createTestProgramRepository([]),
   };
@@ -115,7 +122,9 @@ test('parseInstruction returns unknown for unregistered program', (t) => {
   t.is(result.index, 2);
   t.is(result.programName, 'unknown');
   t.is(result.instructionName, 'unknown');
-  t.deepEqual(result.data, new Uint8Array([1, 2, 3]));
+  t.is(result.status, 'unknown-program');
+  t.is(result.data, null);
+  t.deepEqual(result.rawData, new Uint8Array([1, 2, 3]));
   t.is(result.accounts.length, 1);
   t.is(result.accounts[0].name, undefined);
 });
@@ -131,7 +140,7 @@ test('parseInstruction defaults index to 0', (t) => {
   t.is(result.index, 0);
 });
 
-test('parseInstruction returns unknown instruction for program with no descriptors', (t) => {
+test('parseInstruction returns no-descriptors for program with no descriptors', (t) => {
   const program = createTestProgram({
     name: 'myProgram',
     publicKey: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
@@ -147,7 +156,9 @@ test('parseInstruction returns unknown instruction for program with no descripto
   const result = parseInstruction(context, instruction);
   t.is(result.programName, 'myProgram');
   t.is(result.instructionName, 'unknown');
-  t.deepEqual(result.data, new Uint8Array([1, 2, 3]));
+  t.is(result.status, 'no-descriptors');
+  t.is(result.data, null);
+  t.deepEqual(result.rawData, new Uint8Array([1, 2, 3]));
 });
 
 test('parseInstruction deserializes matching instruction', (t) => {
@@ -200,13 +211,15 @@ test('parseInstruction deserializes matching instruction', (t) => {
   const result = parseInstruction(context, instruction);
   t.is(result.programName, 'splToken');
   t.is(result.instructionName, 'transfer');
+  t.is(result.status, 'parsed');
   t.deepEqual(result.data, { amount: 42n });
+  t.deepEqual(result.remainingBytes, new Uint8Array());
   t.is(result.accounts[0].name, 'source');
   t.is(result.accounts[1].name, 'destination');
   t.is(result.accounts[2].name, 'authority');
 });
 
-test('parseInstruction returns unknown for non-matching discriminator', (t) => {
+test('parseInstruction returns no-discriminator-match for non-matching discriminator', (t) => {
   const program = createTestProgram({
     name: 'splToken',
     publicKey: publicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
@@ -238,6 +251,7 @@ test('parseInstruction returns unknown for non-matching discriminator', (t) => {
   const result = parseInstruction(context, instruction);
   t.is(result.programName, 'splToken');
   t.is(result.instructionName, 'unknown');
+  t.is(result.status, 'no-discriminator-match');
 });
 
 test('parseInstruction matches 8-byte Anchor discriminator', (t) => {
@@ -277,6 +291,7 @@ test('parseInstruction matches 8-byte Anchor discriminator', (t) => {
   };
   const result = parseInstruction(context, instruction);
   t.is(result.instructionName, 'initialize');
+  t.is(result.status, 'parsed');
   t.deepEqual(result.data, { initialized: true });
 });
 
@@ -326,7 +341,7 @@ test('parseInstruction handles more accounts than accountNames', (t) => {
   t.is(result.accounts[1].name, undefined);
 });
 
-test('parseInstruction falls back to raw data on deserialization failure', (t) => {
+test('parseInstruction returns deserialize-failed on serializer throw', (t) => {
   const program = createTestProgram({
     name: 'myProgram',
     publicKey: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
@@ -357,7 +372,105 @@ test('parseInstruction falls back to raw data on deserialization failure', (t) =
   const result = parseInstruction(context, instruction);
   t.is(result.programName, 'myProgram');
   t.is(result.instructionName, 'failingIx');
-  t.deepEqual(result.data, new Uint8Array([1, 0xff, 0xff]));
+  t.is(result.status, 'deserialize-failed');
+  t.is(result.data, null);
+  t.deepEqual(result.rawData, new Uint8Array([1, 0xff, 0xff]));
+});
+
+test('parseInstruction surfaces unconsumed bytes in remainingBytes', (t) => {
+  const program = createTestProgram({
+    name: 'myProgram',
+    publicKey: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+    instructions: [
+      {
+        name: 'partial',
+        discriminator: { bytes: new Uint8Array([5]) },
+        dataSerializer: {
+          description: 'partial',
+          fixedSize: null,
+          maxSize: null,
+          serialize: () => new Uint8Array(),
+          // Always consumes only the first byte after the discriminator.
+          deserialize: (
+            bytes: Uint8Array,
+            offset = 0
+          ): [{ first: number }, number] => [
+            { first: bytes[offset] },
+            offset + 1,
+          ],
+        },
+      },
+    ],
+  });
+  const context = { programs: createTestProgramRepository([program]) };
+  const result = parseInstruction(context, {
+    programId: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+    keys: [],
+    data: new Uint8Array([5, 1, 2, 3]),
+  });
+  t.is(result.status, 'parsed');
+  t.deepEqual(result.data, { first: 1 });
+  t.deepEqual(result.remainingBytes, new Uint8Array([2, 3]));
+});
+
+test('parseInstruction prefers longer discriminators when they overlap a prefix', (t) => {
+  const longSerializer = {
+    description: 'long',
+    fixedSize: 0,
+    maxSize: 0,
+    serialize: () => new Uint8Array(),
+    deserialize: (_b: Uint8Array, o = 0): [{ kind: string }, number] => [
+      { kind: 'long' },
+      o,
+    ],
+  };
+  const shortSerializer = {
+    description: 'short',
+    fixedSize: 0,
+    maxSize: 0,
+    serialize: () => new Uint8Array(),
+    deserialize: (_b: Uint8Array, o = 0): [{ kind: string }, number] => [
+      { kind: 'short' },
+      o,
+    ],
+  };
+  const program = createTestProgram({
+    name: 'p',
+    publicKey: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+    instructions: [
+      // Short registered first; without length-desc sort, the long discriminator
+      // would be unreachable.
+      {
+        name: 'short',
+        discriminator: { bytes: new Uint8Array([1]) },
+        dataSerializer: shortSerializer,
+      },
+      {
+        name: 'long',
+        discriminator: { bytes: new Uint8Array([1, 2, 3]) },
+        dataSerializer: longSerializer,
+      },
+    ],
+  });
+  const context = { programs: createTestProgramRepository([program]) };
+
+  const longResult = parseInstruction(context, {
+    programId: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+    keys: [],
+    data: new Uint8Array([1, 2, 3]),
+  });
+  t.is(longResult.instructionName, 'long', 'longest match wins');
+
+  const shortResult = parseInstruction(context, {
+    programId: publicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'),
+    keys: [],
+    data: new Uint8Array([1, 9]),
+  });
+  t.is(
+    shortResult.instructionName,
+    'short',
+    'short matches when long does not'
+  );
 });
 
 // Helper: create a minimal Transaction from compiled instructions.
@@ -424,10 +537,19 @@ test('parseTransaction returns ParsedTransaction with metadata fields', (t) => {
   t.is(result.version, 'legacy');
   t.is(result.feePayer, feePayer);
   t.is(result.blockhash, 'my-blockhash');
+  t.deepEqual(result.header, {
+    numRequiredSignatures: 1,
+    numReadonlySignedAccounts: 0,
+    numReadonlyUnsignedAccounts: 1,
+  });
+  t.deepEqual(result.staticAccounts, [feePayer, programKey]);
+  t.is(result.loadedAddresses, null);
   t.is(result.signatures.length, 1);
   t.deepEqual(result.signatures[0], sig);
   t.deepEqual(result.addressLookupTables, []);
   t.is(result.instructions.length, 1);
+  t.is(result.innerInstructions, null);
+  t.is(result.meta, null);
 });
 
 test('parseTransaction assigns sequential indexes to instructions', (t) => {
@@ -548,7 +670,7 @@ test('parseTransaction handles multiple instructions', (t) => {
   t.is(result.instructions[0].programName, 'program1');
   t.is(result.instructions[0].instructionName, 'ix1');
   t.is(result.instructions[1].programName, 'program2');
-  t.is(result.instructions[1].instructionName, 'unknown');
+  t.is(result.instructions[1].status, 'no-descriptors');
 });
 
 test('parseTransaction handles empty transaction', (t) => {
@@ -565,9 +687,9 @@ test('parseTransaction handles empty transaction', (t) => {
 test('parseTransaction correctly derives isSigner and isWritable for legacy accounts', (t) => {
   // Layout: [writableSigner(0), readonlySigner(1), writableNonSigner(2), readonlyNonSigner(3), programKey(4)]
   // numRequired=2, numReadonlySigned=1, numReadonlyUnsigned=2
-  //   Writable signers: [0]  (numRequired - numReadonlySigned = 1)
+  //   Writable signers: [0]
   //   Readonly signers: [1]
-  //   Writable non-signers: [2]  (numStaticAccounts(5) - numReadonlyUnsigned(2) = 3 → indices < 3)
+  //   Writable non-signers: [2]
   //   Readonly non-signers: [3, 4]
   const writableSigner = publicKey(
     '3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu'
@@ -618,12 +740,18 @@ test('parseTransaction correctly derives isSigner and isWritable for legacy acco
   t.false(accounts[3].isWritable);
 });
 
-test('parseTransaction correctly derives isWritable for v0 address lookup table accounts', (t) => {
+test('parseTransaction resolves v0 LUT accounts and writability via loadedAddresses', (t) => {
+  // This test uses the *real* umi message shape: `message.accounts` holds
+  // ONLY static account keys. LUT-resolved accounts live beyond
+  // message.accounts.length and must be supplied via loadedAddresses (or
+  // meta.loadedAddresses).
+  //
   // Static accounts: [signer(w), staticNonSigner(w), staticNonSigner(r), program]
-  //   numRequired=1, numReadonlySigned=0, numReadonlyUnsigned=1 (covers staticNonSigner(r) only)
-  // LUT appends: [lutWritable1, lutWritable2, lutReadonly]
-  // Flat index layout: 0=signer(w), 1=staticNonSigner(w), 2=staticNonSigner(r), 3=program,
-  //                    4=lutWritable1, 5=lutWritable2, 6=lutReadonly
+  //   header: numRequiredSignatures=1, numReadonlySigned=0, numReadonlyUnsigned=2
+  // LUT layout (in flat-index space): writable first, then readonly:
+  //   index 4 = lutWritable1 (LUT writable[0])
+  //   index 5 = lutWritable2 (LUT writable[1])
+  //   index 6 = lutReadonly  (LUT readonly[0])
   const signerKey = publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu');
   const staticWritable = publicKey(
     '29S9SK4gMpWrLHGBgrRJTSkNdfuZjq6Pqxv3tesuAx8s'
@@ -639,16 +767,8 @@ test('parseTransaction correctly derives isWritable for v0 address lookup table 
 
   const context = { programs: createTestProgramRepository([]) };
   const transaction = createTestTransaction(
-    // All 7 accounts flat (static first, then LUT-resolved in order)
-    [
-      signerKey,
-      staticWritable,
-      staticReadonly,
-      programKey,
-      lutWritable1,
-      lutWritable2,
-      lutReadonly,
-    ],
+    // Real-shape: only static accounts in message.accounts.
+    [signerKey, staticWritable, staticReadonly, programKey],
     [
       {
         programIndex: 3,
@@ -656,7 +776,6 @@ test('parseTransaction correctly derives isWritable for v0 address lookup table 
         data: new Uint8Array([0]),
       },
     ],
-    // numReadonlyUnsigned=2 → static non-signers at indices [1,2,3]: last 2 are readonly → index 1 writable, indices 2,3 readonly
     {
       numRequiredSignatures: 1,
       numReadonlySignedAccounts: 0,
@@ -665,42 +784,177 @@ test('parseTransaction correctly derives isWritable for v0 address lookup table 
     {
       version: 0,
       addressLookupTables: [
-        { publicKey: lutKey, writableIndexes: [0, 1], readonlyIndexes: [2] },
+        // Indexes here are positions inside the LUT account itself, not
+        // flat-index positions in the message.
+        { publicKey: lutKey, writableIndexes: [10, 20], readonlyIndexes: [30] },
       ],
     }
   );
 
-  const result = parseTransaction(context, transaction);
+  const result = parseTransaction(context, transaction, {
+    loadedAddresses: {
+      writable: [lutWritable1, lutWritable2],
+      readonly: [lutReadonly],
+    },
+  });
   const accounts = result.instructions[0].accounts;
 
-  // index 0: signer, writable
+  // Static signer, writable
+  t.is(accounts[0].pubkey, signerKey);
   t.true(accounts[0].isSigner);
   t.true(accounts[0].isWritable);
 
-  // index 1: static non-signer, writable
+  // Static non-signer, writable
+  t.is(accounts[1].pubkey, staticWritable);
   t.false(accounts[1].isSigner);
   t.true(accounts[1].isWritable);
 
-  // index 2: static non-signer, readonly
+  // Static non-signer, readonly
+  t.is(accounts[2].pubkey, staticReadonly);
   t.false(accounts[2].isSigner);
   t.false(accounts[2].isWritable);
 
-  // index 4: first LUT account — writable
+  // LUT writable[0]
+  t.is(accounts[3].pubkey, lutWritable1);
   t.false(accounts[3].isSigner);
   t.true(accounts[3].isWritable);
 
-  // index 5: second LUT account — writable
+  // LUT writable[1]
+  t.is(accounts[4].pubkey, lutWritable2);
   t.false(accounts[4].isSigner);
   t.true(accounts[4].isWritable);
 
-  // index 6: third LUT account — readonly
+  // LUT readonly[0]
+  t.is(accounts[5].pubkey, lutReadonly);
   t.false(accounts[5].isSigner);
   t.false(accounts[5].isWritable);
 
-  // ParsedTransaction also carries the LUT metadata
+  // ParsedTransaction also carries the LUT metadata and the resolved load.
   t.is(result.version, 0);
+  t.deepEqual(result.staticAccounts, [
+    signerKey,
+    staticWritable,
+    staticReadonly,
+    programKey,
+  ]);
   t.is(result.addressLookupTables.length, 1);
   t.is(result.addressLookupTables[0].publicKey, lutKey);
+  t.deepEqual(result.loadedAddresses, {
+    writable: [lutWritable1, lutWritable2],
+    readonly: [lutReadonly],
+  });
+});
+
+test('parseTransaction throws if v0 LUT accounts are referenced without loadedAddresses', (t) => {
+  const signerKey = publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu');
+  const programKey = publicKey('11111111111111111111111111111111');
+  const lutKey = publicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+  const context = { programs: createTestProgramRepository([]) };
+  const transaction = createTestTransaction(
+    [signerKey, programKey],
+    [
+      {
+        programIndex: 1,
+        // index 2 is past the static account count — needs loadedAddresses.
+        accountIndexes: [0, 2],
+        data: new Uint8Array([0]),
+      },
+    ],
+    {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 1,
+    },
+    {
+      version: 0,
+      addressLookupTables: [
+        { publicKey: lutKey, writableIndexes: [0], readonlyIndexes: [] },
+      ],
+    }
+  );
+  t.throws(() => parseTransaction(context, transaction), {
+    message: /Cannot resolve account at flat index 2/,
+  });
+});
+
+test('parseTransaction surfaces meta and parses inner instructions', (t) => {
+  const programKey = publicKey('11111111111111111111111111111111');
+  const signer = publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu');
+  const dest = publicKey('29S9SK4gMpWrLHGBgrRJTSkNdfuZjq6Pqxv3tesuAx8s');
+
+  const systemProgram = createTestProgram({
+    name: 'systemProgram',
+    publicKey: programKey,
+    instructions: [
+      {
+        name: 'transfer',
+        discriminator: { bytes: new Uint8Array([2, 0, 0, 0]) },
+        dataSerializer: struct([['lamports', u64()]]),
+        accountNames: ['from', 'to'],
+      },
+    ],
+  });
+  const context = { programs: createTestProgramRepository([systemProgram]) };
+
+  const meta: TransactionMeta = {
+    fee: lamports(5000),
+    logs: ['log line'],
+    preBalances: [lamports(1_000_000n), lamports(0n), lamports(0n)],
+    postBalances: [lamports(900_000n), lamports(100_000n), lamports(0n)],
+    preTokenBalances: [],
+    postTokenBalances: [],
+    innerInstructions: [
+      {
+        index: 0,
+        instructions: [
+          {
+            programIndex: 2,
+            accountIndexes: [0, 1],
+            data: new Uint8Array([2, 0, 0, 0, 64, 75, 76, 0, 0, 0, 0, 0]),
+          },
+        ],
+      },
+    ],
+    loadedAddresses: { writable: [], readonly: [] },
+    computeUnitsConsumed: 1000n,
+    costUnits: 1000n,
+    err: null,
+  };
+
+  const baseTx = createTestTransaction(
+    [signer, dest, programKey],
+    [
+      {
+        programIndex: 2,
+        accountIndexes: [0, 1],
+        data: new Uint8Array([2, 0, 0, 0, 32, 161, 7, 0, 0, 0, 0, 0]),
+      },
+    ],
+    {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 1,
+    }
+  );
+  const transaction: TransactionWithMeta = { ...baseTx, meta };
+
+  const result = parseTransaction(context, transaction);
+  t.is(result.meta, meta);
+  t.is(result.instructions.length, 1);
+  t.is(result.instructions[0].instructionName, 'transfer');
+  t.deepEqual(result.instructions[0].data, { lamports: 500_000n });
+
+  t.truthy(result.innerInstructions);
+  t.is(result.innerInstructions!.length, 1);
+  t.is(result.innerInstructions![0].index, 0);
+  t.is(result.innerInstructions![0].instructions.length, 1);
+  t.is(
+    result.innerInstructions![0].instructions[0].instructionName,
+    'transfer'
+  );
+  t.deepEqual(result.innerInstructions![0].instructions[0].data, {
+    lamports: 5_000_000n,
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -708,26 +962,6 @@ test('parseTransaction correctly derives isWritable for v0 address lookup table 
 // ---------------------------------------------------------------------------
 // Data sourced from mainnet transaction:
 // 5x4EHRTNKwDvdhNgR4XdQFunEcyMzBPbTrdPB9dix6N8L5SBoGshJR1NYDj8M8ttcrYSdVPmrWihz91SDa8Bdx7C
-//
-// This transaction contains:
-//   - Instruction 4: System Program Transfer (2) — 499_550_001 lamports
-//   - Instruction 7: SPL Token CloseAccount (9)
-//   - Instruction 8: System Program Transfer (2) — 5_000_000 lamports
-//   - Instruction 9: System Program Transfer (2) — 500_000 lamports
-//
-// Account list (27 accounts):
-//   [0]  3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu  (signer, writable)
-//   [1]  29S9SK4gMpWrLHGBgrRJTSkNdfuZjq6Pqxv3tesuAx8s  (writable)
-//   ...
-//   [6]  CTvW9dwKcHH81CgqaDv39bpYT89RsdMda4cWLGPnNQDu  (writable)
-//   ...
-//   [8]  DXfkEGoo6WFsdL7x6gLZ7r6Hw2S6HrtrAQVPWYx2A1s9  (writable)
-//   ...
-//   [11] 11111111111111111111111111111111                (readonly)
-//   ...
-//   [25] TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA    (readonly)
-//
-// Header: numRequiredSignatures=1, numReadonlySignedAccounts=0, numReadonlyUnsignedAccounts=16
 
 const MAINNET_ACCOUNTS: PublicKey[] = [
   publicKey('3GQMfaCNDRirN24DTYRK5XZLyZjoMgHPvyPxgHKAXiAu'), // 0
@@ -766,19 +1000,14 @@ const MAINNET_HEADER = {
 };
 
 test('parseTransaction parses real mainnet System Program transfers', (t) => {
-  // After the 4-byte discriminator is stripped, we only need the u64 lamports.
   const lamportsSerializer = struct([['lamports', u64()]]);
-
   const systemProgram = createTestProgram({
     name: 'systemProgram',
     publicKey: publicKey('11111111111111111111111111111111'),
     instructions: [
       {
         name: 'transfer',
-        // System Program Transfer has u32 discriminator = 2
-        discriminator: {
-          bytes: new Uint8Array([2, 0, 0, 0]),
-        },
+        discriminator: { bytes: new Uint8Array([2, 0, 0, 0]) },
         dataSerializer: lamportsSerializer,
         accountNames: ['from', 'to'],
       },
@@ -786,24 +1015,19 @@ test('parseTransaction parses real mainnet System Program transfers', (t) => {
   });
 
   const context = { programs: createTestProgramRepository([systemProgram]) };
-
-  // Build transaction with the 3 real transfer instructions from mainnet
   const transaction = createTestTransaction(
     MAINNET_ACCOUNTS,
     [
-      // Instruction 4: Transfer 499_550_001 lamports from [0] to [6]
       {
         programIndex: 11,
         accountIndexes: [0, 6],
         data: new Uint8Array([2, 0, 0, 0, 49, 135, 198, 29, 0, 0, 0, 0]),
       },
-      // Instruction 8: Transfer 5_000_000 lamports from [0] to [8]
       {
         programIndex: 11,
         accountIndexes: [0, 8],
         data: new Uint8Array([2, 0, 0, 0, 64, 75, 76, 0, 0, 0, 0, 0]),
       },
-      // Instruction 9: Transfer 500_000 lamports from [0] to [3]
       {
         programIndex: 11,
         accountIndexes: [0, 3],
@@ -815,11 +1039,7 @@ test('parseTransaction parses real mainnet System Program transfers', (t) => {
 
   const result = parseTransaction(context, transaction);
   t.is(result.instructions.length, 3);
-
-  // Fee payer is always accounts[0]
   t.is(result.feePayer, MAINNET_ACCOUNTS[0]);
-
-  // First transfer: 499_550_001 lamports
   t.is(result.instructions[0].index, 0);
   t.is(result.instructions[0].programName, 'systemProgram');
   t.is(result.instructions[0].instructionName, 'transfer');
@@ -828,16 +1048,8 @@ test('parseTransaction parses real mainnet System Program transfers', (t) => {
   t.is(result.instructions[0].accounts[0].pubkey, MAINNET_ACCOUNTS[0]);
   t.is(result.instructions[0].accounts[1].name, 'to');
   t.is(result.instructions[0].accounts[1].pubkey, MAINNET_ACCOUNTS[6]);
-
-  // Second transfer: 5_000_000 lamports
-  t.is(result.instructions[1].index, 1);
-  t.is(result.instructions[1].instructionName, 'transfer');
   t.deepEqual(result.instructions[1].data, { lamports: 5000000n });
   t.is(result.instructions[1].accounts[1].pubkey, MAINNET_ACCOUNTS[8]);
-
-  // Third transfer: 500_000 lamports
-  t.is(result.instructions[2].index, 2);
-  t.is(result.instructions[2].instructionName, 'transfer');
   t.deepEqual(result.instructions[2].data, { lamports: 500000n });
   t.is(result.instructions[2].accounts[1].pubkey, MAINNET_ACCOUNTS[3]);
 });
@@ -849,7 +1061,6 @@ test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
     instructions: [
       {
         name: 'closeAccount',
-        // SPL Token CloseAccount = u8 discriminator 9, no additional data
         discriminator: { bytes: new Uint8Array([9]) },
         dataSerializer: {
           description: 'closeAccountData',
@@ -867,9 +1078,6 @@ test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
   });
 
   const context = { programs: createTestProgramRepository([splToken]) };
-
-  // Instruction 7 from the real transaction: CloseAccount
-  // accounts: [6, 0, 0] = [CTvW9d..., 3GQMfa..., 3GQMfa...]
   const transaction = createTestTransaction(
     MAINNET_ACCOUNTS,
     [
@@ -881,7 +1089,6 @@ test('parseTransaction parses real mainnet SPL Token CloseAccount', (t) => {
     ],
     MAINNET_HEADER
   );
-
   const result = parseTransaction(context, transaction);
   t.is(result.instructions.length, 1);
   t.is(result.instructions[0].programName, 'splToken');
@@ -908,26 +1115,20 @@ test('parseTransaction handles mix of known and unknown programs from real mainn
       },
     ],
   });
-
-  // Only register System Program — leave SPL Token and others unregistered
   const context = { programs: createTestProgramRepository([systemProgram]) };
-
   const transaction = createTestTransaction(
     MAINNET_ACCOUNTS,
     [
-      // System Program Transfer — will be parsed
       {
         programIndex: 11,
         accountIndexes: [0, 6],
         data: new Uint8Array([2, 0, 0, 0, 49, 135, 198, 29, 0, 0, 0, 0]),
       },
-      // SPL Token CloseAccount — program not registered, will be unknown
       {
         programIndex: 25,
         accountIndexes: [6, 0, 0],
         data: new Uint8Array([9]),
       },
-      // ComputeBudget — program not registered, will be unknown
       {
         programIndex: 19,
         accountIndexes: [],
@@ -939,19 +1140,16 @@ test('parseTransaction handles mix of known and unknown programs from real mainn
 
   const result = parseTransaction(context, transaction);
   t.is(result.instructions.length, 3);
-
-  // Known: System Program Transfer
   t.is(result.instructions[0].programName, 'systemProgram');
   t.is(result.instructions[0].instructionName, 'transfer');
   t.deepEqual(result.instructions[0].data, { lamports: 499550001n });
-
-  // Unknown: SPL Token (not registered)
   t.is(result.instructions[1].programName, 'unknown');
-  t.is(result.instructions[1].instructionName, 'unknown');
-  t.deepEqual(result.instructions[1].data, new Uint8Array([9]));
-
-  // Unknown: ComputeBudget (not registered)
+  t.is(result.instructions[1].status, 'unknown-program');
+  t.deepEqual(result.instructions[1].rawData, new Uint8Array([9]));
   t.is(result.instructions[2].programName, 'unknown');
-  t.is(result.instructions[2].instructionName, 'unknown');
-  t.deepEqual(result.instructions[2].data, new Uint8Array([2, 166, 126, 3, 0]));
+  t.is(result.instructions[2].status, 'unknown-program');
+  t.deepEqual(
+    result.instructions[2].rawData,
+    new Uint8Array([2, 166, 126, 3, 0])
+  );
 });


### PR DESCRIPTION
## Summary

Follow-up fixes for the transaction parser introduced in #202 / #208. The current implementation has a correctness bug for v0 transactions that use address lookup tables, and `ParsedTransaction` drops several pieces of information that can be parsed from the input.

This PR is targeted at `feat/transaction-parser` so it can be folded into the parent PR before it merges.

### What's broken today

`resolveAccountMeta` computes:

```ts
const numStaticAccounts = message.accounts.length - numLutAccounts;
```

But `message.accounts` only ever contains **static** account keys — `fromWeb3JsMessage` sets it from `staticAccountKeys` (`packages/umi-web3js-adapters/src/TransactionMessage.ts:20`). The subtraction therefore produces a too-small static count.

Reproduction with a real-shape v0 message (4 static accounts + 1 LUT carrying 2 writable + 1 readonly):

```
out[0] pubkey=<signer>     signer=true  writable=true     ✓
out[1] pubkey=<staticW>    signer=false writable=true     ✓ (lucky)
out[2] pubkey=<staticR>    signer=false writable=true     ✗ should be readonly
out[3] pubkey=undefined    signer=false writable=false    ✗ pubkey undefined; should be writable
out[4] pubkey=undefined    signer=false writable=false    ✗
out[5] pubkey=undefined    signer=false writable=false    ✓ readonly flag, but pubkey undefined
```

The existing v0 LUT test passed only because it stuffed all 7 accounts (static + LUT) into `message.accounts`, which doesn't match how umi actually decompiles v0 messages.

### Fixes

- **`resolveAccountMeta`** treats `message.accounts.length` as the static count directly (it already is). LUT-resolved indices fall through to the LUT branch unchanged.
- **`parseTransaction` accepts `TransactionWithMeta`** and an optional `loadedAddresses` parameter. LUT-resolved pubkeys come from `meta.loadedAddresses` or `options.loadedAddresses`. Throws a clear error when LUT references exist but neither is supplied.
- **`meta.innerInstructions` are decompiled and parsed** into `ParsedInnerInstructions[]`.
- **`ParsedTransaction` surfaces** `header`, `staticAccounts`, `loadedAddresses`, `meta`, and `innerInstructions` — all the parseable info on the input.
- **`ParsedInstruction` gains** a `status` discriminator (`'parsed' | 'unknown-program' | 'no-descriptors' | 'no-discriminator-match' | 'deserialize-failed'`), an always-present `rawData`, and `remainingBytes` for any input the data serializer didn't consume (a useful malformed-instruction signal).
- **Descriptor matching is longest-first**, so a one-byte discriminator registered before a longer one in the same program no longer shadows it.
- **`parseInstruction` / `parseTransaction` accept `clusterFilter`** (default `'*'`), decoupling the parser from the umi instance's current cluster — important for parsing mainnet transactions against a devnet-configured umi.

### Replaced/added tests

- The synthetic "v0 LUT" test was replaced with one that uses the real umi message shape (static-only `accounts`) and verifies pubkey resolution + signer/writable flags via supplied `loadedAddresses`.
- Added tests for: throwing when LUT data is missing, surfacing meta + parsing inner instructions, longest-discriminator preference, and `remainingBytes` on partial consumption.
- Updated existing tests for the new `status` / `rawData` shape.

## Test plan

- [x] `pnpm build` (workspace) passes
- [x] `pnpm test` in `packages/umi` — 60 passed, 3 skipped
- [x] `pnpm lint` (workspace) clean
- [x] `pnpm format` clean
- [x] Real-shape v0 reproduction now passes (was failing on `static readonly`/LUT pubkey/LUT writability)

https://claude.ai/code/session_01Wqbw6faVn5M38iRZMj8gFp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wqbw6faVn5M38iRZMj8gFp)_