### PR TITLE
Use cross-fetch for fetch HTTP

### DIFF
--- a/packages/umi-http-fetch/package.json
+++ b/packages/umi-http-fetch/package.json
@@ -30,7 +30,7 @@
     "server:stop": "kill $(lsof -t -i:3000) 2> /dev/null || true"
   },
   "dependencies": {
-    "node-fetch": "^2.6.7"
+    "cross-fetch": "^3.1.5"
   },
   "peerDependencies": {
     "@metaplex-foundation/umi": "workspace:^"
@@ -38,7 +38,6 @@
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
     "@metaplex-foundation/umi": "workspace:^",
-    "@types/node-fetch": "^2.6.2",
     "ava": "^5.1.0",
     "json-server": "^0.17.1"
   },

--- a/packages/umi-http-fetch/src/createFetchHttp.ts
+++ b/packages/umi-http-fetch/src/createFetchHttp.ts
@@ -3,7 +3,12 @@ import {
   HttpRequest,
   HttpResponse,
 } from '@metaplex-foundation/umi';
-import fetch, { BodyInit, RequestInit } from 'node-fetch';
+import fetch from 'cross-fetch';
+
+type FetchRequestInit = RequestInit & {
+  follow?: number;
+  timeout?: number;
+};
 
 export function createFetchHttp(): HttpInterface {
   return {
@@ -33,7 +38,7 @@ export function createFetchHttp(): HttpInterface {
         body = request.data as BodyInit | undefined;
       }
 
-      const requestInit: RequestInit = {
+      const requestInit: FetchRequestInit = {
         method: request.method,
         body,
         headers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,9 +248,9 @@ importers:
 
   packages/umi-http-fetch:
     dependencies:
-      node-fetch:
-        specifier: ^2.6.7
-        version: 2.6.9
+      cross-fetch:
+        specifier: ^3.1.5
+        version: 3.1.5
     devDependencies:
       '@ava/typescript':
         specifier: ^3.0.1
@@ -258,9 +258,6 @@ importers:
       '@metaplex-foundation/umi':
         specifier: workspace:^
         version: link:../umi
-      '@types/node-fetch':
-        specifier: ^2.6.2
-        version: 2.6.2
       ava:
         specifier: ^5.1.0
         version: 5.1.0(@ava/typescript@3.0.1)
@@ -8804,7 +8801,6 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: false
-    optional: true
 
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}


### PR DESCRIPTION
## Summary

Replace the direct `node-fetch` dependency in `@metaplex-foundation/umi-http-fetch` with `cross-fetch` so the fetch HTTP implementation is friendlier to browser/bundler environments.

Closes #178.

## Changes

- Import fetch from `cross-fetch`
- Replace `node-fetch` with `cross-fetch` in `umi-http-fetch`
- Keep the existing `follow` and `timeout` options through a small compatibility type
- Update the lockfile

## Testing

- `pnpm --filter @metaplex-foundation/umi-http-fetch lint`
- `pnpm --filter @metaplex-foundation/umi-http-fetch... build`
- `ava` for `umi-http-fetch`: 3 passed, 1 existing skipped