### PR TITLE
fix(umi): resolve @metaplex-foundation/umi/serializers without package exports

### DIFF
--- a/.changeset/fix-serializers-subpath.md
+++ b/.changeset/fix-serializers-subpath.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/umi": patch
+---
+
+Add filesystem fallbacks (`serializers.js` / `serializers.mjs`) and a `default` export condition so `@metaplex-foundation/umi/serializers` resolves in environments that do not honor package.json `exports` (older Jest, Metro/React Native without package-exports enabled). Also export `./package.json` for tooling that needs it.

--- a/packages/umi/package.json
+++ b/packages/umi/package.json
@@ -11,21 +11,26 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "default": "./dist/cjs/index.cjs"
     },
     "./serializers": {
       "react-native": "./dist/cjs/serializers.cjs",
       "types": "./dist/types/serializers.d.ts",
       "import": "./dist/esm/serializers.mjs",
-      "require": "./dist/cjs/serializers.cjs"
-    }
+      "require": "./dist/cjs/serializers.cjs",
+      "default": "./dist/cjs/serializers.cjs"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "/dist/cjs",
     "/dist/esm",
     "/dist/types",
     "/src",
-    "*.d.ts"
+    "*.d.ts",
+    "serializers.js",
+    "serializers.mjs"
   ],
   "scripts": {
     "lint": "eslint --ext js,ts,tsx src",

--- a/packages/umi/serializers.js
+++ b/packages/umi/serializers.js
@@ -1,0 +1,5 @@
+// Filesystem fallback for resolvers that do not honor package.json "exports"
+// (e.g. older Jest, Metro without package-exports enabled).
+// See: https://github.com/metaplex-foundation/umi/issues/175
+// See: https://github.com/metaplex-foundation/umi/issues/94
+module.exports = require('./dist/cjs/serializers.cjs');

--- a/packages/umi/serializers.mjs
+++ b/packages/umi/serializers.mjs
@@ -1,0 +1,5 @@
+// Filesystem fallback for resolvers that do not honor package.json "exports"
+// (e.g. older Jest, Metro without package-exports enabled).
+// See: https://github.com/metaplex-foundation/umi/issues/175
+// See: https://github.com/metaplex-foundation/umi/issues/94
+export * from './dist/esm/serializers.mjs';


### PR DESCRIPTION
## Problem

`@metaplex-foundation/umi/serializers` is only exposed via package.json `exports`. Resolvers that do not honor `exports` (older Jest, Metro/React Native without package-exports enabled) fail with:

```
Cannot find module '@metaplex-foundation/umi/serializers'
```

This shows up when requiring packages such as `@metaplex-foundation/umi-transaction-factory-web3js` that import the subpath (see #175; also #94).

## Changes

- Add root `serializers.js` / `serializers.mjs` filesystem fallbacks that re-export the built CJS/ESM serializers entrypoints
- Add a `default` condition on package exports for broader tooling support
- Export `./package.json` for tooling that needs it
- Include the new root files in the published `files` list
- Changeset (patch)

## Fixes

Fixes #175

## Verification

- `pnpm build --filter=@metaplex-foundation/umi...` — success
- `pnpm --filter @metaplex-foundation/umi test` — 46 passed, 3 skipped
- `npm pack` of the local package includes `serializers.js` and `serializers.mjs`
- Classic resolution finds `package/serializers.js` when package `exports` are stripped

## Notes

With Node's modern `exports` support, resolution still prefers the export map. The root files only matter for tools that fall back to filesystem resolution (the failure mode reported in #175 / #94).
