### PR TITLE
fix(umi-rpc-web3js): chunk getAccounts and paginate oversized GPA

### DIFF
--- a/.changeset/fix-gpa-pagination-chunk-accounts.md
+++ b/.changeset/fix-gpa-pagination-chunk-accounts.md
@@ -1,0 +1,5 @@
+---
+"@metaplex-foundation/umi-rpc-web3js": patch
+---
+
+Chunk `getAccounts` (`getMultipleAccounts`) requests at the Solana RPC limit of 100, and automatically fall back to paginated `getProgramAccountsV2` when providers reject oversized `getProgramAccounts` result sets (e.g. Helius "Too many accounts requested").

--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -5,6 +5,7 @@ import {
   Commitment,
   CompiledInstruction,
   Context,
+  chunk,
   createAmount,
   DateTime,
   dateTime,
@@ -67,6 +68,15 @@ import type RpcClient from 'jayson/lib/client/browser';
 
 export type Web3JsRpcOptions = Commitment | Web3JsConnectionConfig;
 
+/** Solana RPC limit for `getMultipleAccounts` pubkeys per request. */
+export const GET_MULTIPLE_ACCOUNTS_LIMIT = 100;
+
+/**
+ * Default page size when falling back to `getProgramAccountsV2` pagination
+ * (Helius and other providers that enforce result-set limits on GPA).
+ */
+export const GET_PROGRAM_ACCOUNTS_V2_PAGE_LIMIT = 10_000;
+
 export function createWeb3JsRpc(
   context: Pick<Context, 'programs' | 'transactions'>,
   endpoint: string,
@@ -107,7 +117,7 @@ export function createWeb3JsRpc(
     return parseMaybeAccount(account, publicKey);
   };
 
-  const getAccounts = async (
+  const getAccountsChunk = async (
     publicKeys: PublicKey[],
     options: RpcGetAccountsOptions = {}
   ): Promise<MaybeRpcAccount[]> => {
@@ -120,20 +130,123 @@ export function createWeb3JsRpc(
     );
   };
 
+  /**
+   * Fetch multiple accounts, automatically chunking requests to stay within
+   * the Solana RPC `getMultipleAccounts` limit (100 pubkeys per request).
+   */
+  const getAccounts = async (
+    publicKeys: PublicKey[],
+    options: RpcGetAccountsOptions = {}
+  ): Promise<MaybeRpcAccount[]> => {
+    if (publicKeys.length <= GET_MULTIPLE_ACCOUNTS_LIMIT) {
+      return getAccountsChunk(publicKeys, options);
+    }
+
+    const batches = chunk(publicKeys, GET_MULTIPLE_ACCOUNTS_LIMIT);
+    const results = await Promise.all(
+      batches.map((batch) => getAccountsChunk(batch, options))
+    );
+    return results.flat();
+  };
+
+  type ProgramAccountsV2Result = {
+    accounts: Array<{
+      pubkey: string;
+      account: {
+        lamports: number;
+        owner: string;
+        data: [string, string] | string;
+        executable: boolean;
+        rentEpoch?: number;
+      };
+    }>;
+    paginationKey: string | null;
+  };
+
+  const getProgramAccountsViaV2 = async (
+    programId: PublicKey,
+    options: RpcGetProgramAccountsOptions = {}
+  ): Promise<RpcAccount[]> => {
+    const allAccounts: RpcAccount[] = [];
+    let paginationKey: string | null = null;
+
+    /* Sequential pages are required: each request needs the previous cursor. */
+    /* eslint-disable no-await-in-loop */
+    do {
+      const config: Record<string, unknown> = {
+        encoding: 'base64',
+        limit: GET_PROGRAM_ACCOUNTS_V2_PAGE_LIMIT,
+      };
+      if (options.commitment) config.commitment = options.commitment;
+      if (options.dataSlice) config.dataSlice = options.dataSlice;
+      if (options.filters) {
+        config.filters = options.filters.map((filter) =>
+          parseDataFilter(filter)
+        );
+      }
+      if (paginationKey) config.paginationKey = paginationKey;
+
+      // Commitment is embedded in the config object (Solana GPA config shape).
+      // Do not pass it via RpcCallOptions or `call` will append a third param.
+      const result = await call<ProgramAccountsV2Result>(
+        'getProgramAccountsV2',
+        [programId, config]
+      );
+
+      const page = result?.accounts ?? [];
+      page.forEach(({ pubkey, account }) => {
+        const rawData = Array.isArray(account.data)
+          ? account.data[0]
+          : account.data;
+        const data = Uint8Array.from(Buffer.from(rawData, 'base64'));
+        allAccounts.push(
+          parseAccount(
+            {
+              executable: account.executable,
+              owner: new Web3JsPublicKey(account.owner),
+              lamports: account.lamports,
+              data,
+              rentEpoch: account.rentEpoch,
+            } as Web3JsAccountInfo<Uint8Array>,
+            fromWeb3JsPublicKey(new Web3JsPublicKey(pubkey))
+          )
+        );
+      });
+
+      // Continue while a cursor is present. Empty pages with a null cursor end the loop.
+      paginationKey = result?.paginationKey ?? null;
+      if (page.length === 0 && !paginationKey) {
+        break;
+      }
+    } while (paginationKey);
+    /* eslint-enable no-await-in-loop */
+
+    return allAccounts;
+  };
+
   const getProgramAccounts = async (
     programId: PublicKey,
     options: RpcGetProgramAccountsOptions = {}
   ): Promise<RpcAccount[]> => {
-    const accounts = await getConnection().getProgramAccounts(
-      toWeb3JsPublicKey(programId),
-      {
-        ...options,
-        filters: options.filters?.map((filter) => parseDataFilter(filter)),
+    try {
+      const accounts = await getConnection().getProgramAccounts(
+        toWeb3JsPublicKey(programId),
+        {
+          ...options,
+          filters: options.filters?.map((filter) => parseDataFilter(filter)),
+        }
+      );
+      return accounts.map(({ pubkey, account }) =>
+        parseAccount(account, fromWeb3JsPublicKey(pubkey))
+      );
+    } catch (error) {
+      // Providers such as Helius reject oversized GPA result sets and recommend
+      // getProgramAccountsV2 with cursor-based pagination (see umi#200).
+      if (!isTooManyAccountsError(error)) {
+        throw error;
       }
-    );
-    return accounts.map(({ pubkey, account }) =>
-      parseAccount(account, fromWeb3JsPublicKey(pubkey))
-    );
+      return getProgramAccountsViaV2(programId, options);
+    }
   };
 
   const getBlockTime = async (
@@ -462,6 +575,23 @@ function parseMaybeAccount(
   return account
     ? { ...parseAccount(account, publicKey), exists: true }
     : { exists: false, publicKey };
+}
+
+function isTooManyAccountsError(error: unknown): boolean {
+  let message = '';
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === 'string') {
+    message = error;
+  } else if (error && typeof error === 'object' && 'message' in error) {
+    message = String((error as { message: unknown }).message);
+  } else {
+    message = String(error);
+  }
+  return (
+    /too many accounts requested/i.test(message) ||
+    /getProgramAccountsV2/i.test(message)
+  );
 }
 
 function parseDataFilter(

--- a/packages/umi-rpc-web3js/test/getAccountsAndGpa.test.ts
+++ b/packages/umi-rpc-web3js/test/getAccountsAndGpa.test.ts
@@ -1,0 +1,162 @@
+import { createNullContext, publicKey } from '@metaplex-foundation/umi';
+import { Keypair, PublicKey as Web3JsPublicKey } from '@solana/web3.js';
+import test from 'ava';
+import {
+  createWeb3JsRpc,
+  GET_MULTIPLE_ACCOUNTS_LIMIT,
+} from '../src';
+
+const SYSTEM_PROGRAM = '11111111111111111111111111111111';
+
+function makeAccountInfo(overrides: Partial<{
+  lamports: number;
+  owner: Web3JsPublicKey;
+  data: Uint8Array;
+  executable: boolean;
+  rentEpoch: number;
+}> = {}) {
+  return {
+    lamports: overrides.lamports ?? 1_000_000,
+    owner: overrides.owner ?? new Web3JsPublicKey(SYSTEM_PROGRAM),
+    data: overrides.data ?? new Uint8Array([1, 2, 3]),
+    executable: overrides.executable ?? false,
+    rentEpoch: overrides.rentEpoch ?? 0,
+  };
+}
+
+test('getAccounts chunks requests over the getMultipleAccounts limit', async (t) => {
+  const keys = Array.from({ length: GET_MULTIPLE_ACCOUNTS_LIMIT + 25 }, () =>
+    publicKey(Keypair.generate().publicKey.toBase58())
+  );
+
+  const callSizes: number[] = [];
+  const connection = {
+    rpcEndpoint: 'http://127.0.0.1:8899',
+    getMultipleAccountsInfo: async (web3Keys: Web3JsPublicKey[]) => {
+      callSizes.push(web3Keys.length);
+      return web3Keys.map(() => makeAccountInfo());
+    },
+  } as any;
+
+  const rpc = createWeb3JsRpc(createNullContext(), connection);
+  const accounts = await rpc.getAccounts(keys);
+
+  t.is(accounts.length, keys.length);
+  t.deepEqual(callSizes, [GET_MULTIPLE_ACCOUNTS_LIMIT, 25]);
+  t.true(accounts.every((a) => a.exists));
+});
+
+test('getAccounts does not chunk requests within the limit', async (t) => {
+  const keys = Array.from({ length: 10 }, () =>
+    publicKey(Keypair.generate().publicKey.toBase58())
+  );
+
+  let calls = 0;
+  const connection = {
+    rpcEndpoint: 'http://127.0.0.1:8899',
+    getMultipleAccountsInfo: async (web3Keys: Web3JsPublicKey[]) => {
+      calls += 1;
+      t.is(web3Keys.length, 10);
+      return web3Keys.map(() => makeAccountInfo());
+    },
+  } as any;
+
+  const rpc = createWeb3JsRpc(createNullContext(), connection);
+  const accounts = await rpc.getAccounts(keys);
+
+  t.is(calls, 1);
+  t.is(accounts.length, 10);
+});
+
+test('getProgramAccounts falls back to getProgramAccountsV2 pagination on too-many-accounts errors', async (t) => {
+  const programId = publicKey(Keypair.generate().publicKey.toBase58());
+  const page1Key = publicKey(Keypair.generate().publicKey.toBase58());
+  const page2Key = publicKey(Keypair.generate().publicKey.toBase58());
+
+  const v2Calls: Array<{ paginationKey?: string }> = [];
+
+  const connection = {
+    rpcEndpoint: 'https://mainnet.helius-rpc.com',
+    getProgramAccounts: async () => {
+      throw new Error(
+        'failed to get accounts owned by program: Too many accounts requested (5000001 pubkeys), Please use getProgramAccountsV2 with pagination to handle large datasets.'
+      );
+    },
+    _rpcClient: {
+      request: (
+        method: string,
+        params: any[],
+        callback: (err: Error | null, response?: any) => void
+      ) => {
+        t.is(method, 'getProgramAccountsV2');
+        const config = params[1] ?? {};
+        v2Calls.push({ paginationKey: config.paginationKey });
+
+        if (!config.paginationKey) {
+          callback(null, {
+            result: {
+              accounts: [
+                {
+                  pubkey: page1Key,
+                  account: {
+                    lamports: 42,
+                    owner: programId,
+                    data: [Buffer.from([9, 9]).toString('base64'), 'base64'],
+                    executable: false,
+                    rentEpoch: 0,
+                  },
+                },
+              ],
+              paginationKey: page1Key,
+            },
+          });
+          return;
+        }
+
+        callback(null, {
+          result: {
+            accounts: [
+              {
+                pubkey: page2Key,
+                account: {
+                  lamports: 43,
+                  owner: programId,
+                  data: [Buffer.from([8, 8]).toString('base64'), 'base64'],
+                  executable: false,
+                  rentEpoch: 0,
+                },
+              },
+            ],
+            paginationKey: null,
+          },
+        });
+      },
+    },
+  } as any;
+
+  const rpc = createWeb3JsRpc(createNullContext(), connection);
+  const accounts = await rpc.getProgramAccounts(programId);
+
+  t.is(accounts.length, 2);
+  t.is(accounts[0].publicKey, page1Key);
+  t.is(accounts[1].publicKey, page2Key);
+  t.deepEqual(accounts[0].data, new Uint8Array([9, 9]));
+  t.is(v2Calls.length, 2);
+  t.is(v2Calls[0].paginationKey, undefined);
+  t.is(v2Calls[1].paginationKey, page1Key);
+});
+
+test('getProgramAccounts rethrows non-pagination errors', async (t) => {
+  const programId = publicKey(Keypair.generate().publicKey.toBase58());
+  const connection = {
+    rpcEndpoint: 'http://127.0.0.1:8899',
+    getProgramAccounts: async () => {
+      throw new Error('connection refused');
+    },
+  } as any;
+
+  const rpc = createWeb3JsRpc(createNullContext(), connection);
+  await t.throwsAsync(() => rpc.getProgramAccounts(programId), {
+    message: /connection refused/,
+  });
+});


### PR DESCRIPTION
## Problem

`fetchAssetsByOwner` (mpl-core) and other `GpaBuilder` flows call Umi's `rpc.getProgramAccounts`. On large datasets some RPC providers (notably Helius) reject the request with:

```
Too many accounts requested (...), Please use getProgramAccountsV2 with pagination to handle large datasets.
```

Separately, Solana's `getMultipleAccounts` hard-limits requests to **100 pubkeys**. Without chunking, large `getAccounts` calls fail even though `umi-rpc-chunk-get-accounts` already exists as an optional decorator.

## Changes

In `@metaplex-foundation/umi-rpc-web3js`:

1. **`getAccounts`** — automatically chunks requests into batches of 100 (`GET_MULTIPLE_ACCOUNTS_LIMIT`) and runs them in parallel.
2. **`getProgramAccounts`** — on "Too many accounts requested" / `getProgramAccountsV2` errors, falls back to cursor-based **`getProgramAccountsV2`** pagination (page size 10_000) and concatenates all pages.
3. Non-pagination errors still rethrow.
4. Unit tests covering chunking, V2 fallback, and rethrow behavior.
5. Changeset (patch).

## Fixes

Fixes #200

## Verification

- `pnpm build --filter=@metaplex-foundation/umi-rpc-web3js...` — success
- `pnpm lint` in `umi-rpc-web3js` — clean
- Unit tests: `ava dist/test/test/getAccountsAndGpa.test.js` — 4/4 passed:
  - getAccounts does not chunk within limit
  - getAccounts chunks over limit
  - getProgramAccounts rethrows non-pagination errors
  - getProgramAccounts falls back to getProgramAccountsV2 pagination

## Notes

- `getProgramAccountsV2` is currently a provider extension (e.g. Helius). Standard public RPCs that never emit the "too many accounts" error are unchanged.
- Built-in `getAccounts` chunking is complementary to `@metaplex-foundation/umi-rpc-chunk-get-accounts` (already used by bundle-defaults); double-wrapping remains correct.
