### PR TITLE
feat(umi-uploader-cascade): repoint the Cascade uploader to the Lumera gateway

### DIFF
--- a/.changeset/cascade-lumera-gateway.md
+++ b/.changeset/cascade-lumera-gateway.md
@@ -1,0 +1,11 @@
+---
+'@metaplex-foundation/umi-uploader-cascade': minor
+---
+
+Repoint the Cascade uploader to the Lumera gateway (`https://api.lumera.help`); the previous Pastel gateway (`gateway-api.pastel.network`) is offline, which left this package non-functional. Uploads now go through cascade-api and return stable `{endpoint}/download/{action_id}` URIs.
+
+- Propagate upload/download errors instead of swallowing them and returning `[]`, and remove a stray `console.log`.
+- Add an `endpoint` option (defaults to the hosted gateway) and an `archive` mode that packs a whole `upload()` call into a single Cascade action — one fee, with per-file URLs — for large collections.
+- Expose the real cost via `estimate` and `getUploadPriceUlume`; `getUploadPrice` still returns 0 SOL because the fee is paid in LUME by the gateway, not by the Solana caller.
+
+Note: this drops the Pastel-specific `upload2` method and the `CascadeUploadResponse` / `CascadeUploadedItem` types, which described the retired gateway's response shape.

--- a/packages/umi-uploader-cascade/README.md
+++ b/packages/umi-uploader-cascade/README.md
@@ -1,9 +1,68 @@
 # umi-uploader-cascade
 
-An uploader implementation relying on Cascade Protocol.
+A Umi uploader that stores assets **permanently** on [Lumera Cascade](https://lumera.io)
+(pay once, store forever) through a hosted [cascade-api](https://api.lumera.help)
+gateway. The URIs it returns work everywhere Umi's uploader interface is used —
+Token Metadata, Core, Candy Machine, and Bubblegum.
 
 ## Installation
 
 ```sh
 npm install @metaplex-foundation/umi-uploader-cascade
+```
+
+## Usage
+
+```ts
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { cascadeUploader } from '@metaplex-foundation/umi-uploader-cascade';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com').use(
+  cascadeUploader({ apiKey: process.env.CASCADE_API_KEY! })
+);
+
+const [imageUri] = await umi.uploader.upload([imageFile]);
+const metadataUri = await umi.uploader.uploadJson({
+  name: 'My NFT',
+  image: imageUri,
+});
+```
+
+Each URI is a stable, immutable gateway URL:
+`https://api.lumera.help/download/{action_id}`. An API key is issued by the
+gateway operator — see [api.lumera.help](https://api.lumera.help).
+
+### Archive mode (large collections)
+
+Cascade charges `base_action_fee + fee_per_kbyte × size` **per action**, so
+inscribing a 10,000-item collection one file at a time pays the base fee 10,000
+times. Archive mode packs every file from a single `upload()` call into one
+action — one fee — while each file stays individually addressable:
+
+```ts
+umi.use(cascadeUploader({ apiKey, mode: 'archive' }));
+
+const uris = await umi.uploader.upload(collectionImages);
+// -> https://api.lumera.help/download/{action_id}/imgs/1.png, .../imgs/2.png, ...
+```
+
+`uploadJson` always inscribes metadata as its own action, regardless of mode.
+
+### Options
+
+| Option     | Default                   | Description                                                                                    |
+| ---------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `apiKey`   | — (required)              | Bearer key for the gateway's `/upload*` routes                                                 |
+| `endpoint` | `https://api.lumera.help` | Any cascade-api deployment                                                                     |
+| `mode`     | `'file'`                  | `'file'` = one action per file; `'archive'` = one action per `upload()` call, with per-file URLs |
+
+### Pricing
+
+`getUploadPrice()` returns **0 SOL** — the caller pays nothing on Solana; the
+gateway's Lumera key pays the LUME fee, metered against the API key. The real
+cost is exposed instead of hidden:
+
+```ts
+const ulume = await umi.uploader.getUploadPriceUlume(files); // bigint, in ulume
+const quote = await umi.uploader.estimate([1024, 2048]); // per-size breakdown
 ```

--- a/packages/umi-uploader-cascade/src/createCascadeUploader.ts
+++ b/packages/umi-uploader-cascade/src/createCascadeUploader.ts
@@ -11,119 +11,206 @@ import {
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 
-const CASCADE_API_URL = 'https://gateway-api.pastel.network/';
+const DEFAULT_ENDPOINT = 'https://api.lumera.help';
 
 export type CascadeUploaderOptions = {
+  /**
+   * Bearer key for the gateway's `/upload*` routes. The hosted gateway
+   * authenticates and meters every inscription against this key.
+   */
   apiKey: string;
+  /**
+   * Base URL of a cascade-api gateway. Defaults to the hosted gateway at
+   * `https://api.lumera.help`.
+   */
+  endpoint?: string;
+  /**
+   * `'file'` (default): one Cascade action per file — every URI is
+   * `{endpoint}/download/{action_id}`.
+   * `'archive'`: all files from a single `upload()` call are packed into one
+   * Cascade action — URIs are `{endpoint}/download/{action_id}/{fileName}` and
+   * the base fee is paid once for the whole batch. Use this for large
+   * collections (one fee instead of thousands).
+   */
+  mode?: 'file' | 'archive';
 };
 
-export type CascadeUploadedItem = {
-  result_id: string;
-  result_status: string;
-  registration_ticket_txid: string | undefined;
-  original_file_ipfs_link: string | undefined;
-  error: string | undefined;
+export type CascadeEstimate = {
+  totalUlume: bigint;
+  items: Array<{ bytes: number; feeUlume: bigint }>;
 };
 
-export type CascadeUploadResponse = {
-  request_id: string;
-  request_status: string;
-  results: CascadeUploadedItem[];
+type UploadResponse = { action_id?: string };
+type EstimateResponse = {
+  total_ulume?: number | string;
+  items?: Array<{ bytes: number; fee_ulume: number | string }>;
 };
 
 export function createCascadeUploader(
   context: Pick<Context, 'rpc' | 'payer'>,
   options: CascadeUploaderOptions = { apiKey: '' }
 ): UploaderInterface & {
-  upload2: (
-    files: GenericFile[],
-    options?: UploaderUploadOptions
-  ) => Promise<CascadeUploadedItem[]>;
+  /** Quotes the gateway's ulume (LUME) cost for a list of byte sizes. */
+  estimate: (sizes: number[]) => Promise<CascadeEstimate>;
+  /** The ulume the gateway will spend inscribing these files. */
+  getUploadPriceUlume: (files: GenericFile[]) => Promise<bigint>;
 } {
-  const { apiKey } = options;
+  const { apiKey, mode = 'file' } = options;
+  const endpoint = (options.endpoint ?? DEFAULT_ENDPOINT).replace(/\/+$/, '');
 
   if (!apiKey) {
     throw new Error('Cascade Gateway API key is required');
   }
 
-  const getUploadPrice = async (): Promise<SolAmount> => lamports(0);
+  const failure = (
+    method: string,
+    path: string,
+    status: number,
+    body: string
+  ): Error =>
+    new Error(
+      `cascade-api ${method} ${path} failed: HTTP ${status} ${body.slice(
+        0,
+        500
+      )}`
+    );
 
-  const upload = async (files: GenericFile[]): Promise<string[]> => {
-    const uris: string[] = [];
-
-    const body = new FormData();
-
-    files.forEach((file) => {
-      body.append('files', Buffer.from(file.buffer), file.fileName);
+  const postForm = async <T>(path: string, body: FormData): Promise<T> => {
+    const res = await fetch(`${endpoint}${path}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body,
     });
-
+    const text = await res.text();
+    if (!res.ok) throw failure('POST', path, res.status, text);
     try {
-      const res = await fetch(
-        `${CASCADE_API_URL}/api/v1/cascade?make_publicly_accessible=true`,
-        {
-          headers: {
-            Api_key: apiKey,
-          },
-          method: 'POST',
-          body,
-        }
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(
+        `cascade-api ${path} returned non-JSON: ${text.slice(0, 200)}`
       );
-
-      const data: CascadeUploadResponse = await res.json();
-      data.results.forEach((item) => {
-        if (item.original_file_ipfs_link)
-          uris.push(item.original_file_ipfs_link);
-        else {
-          uris.push('');
-        }
-      });
-    } catch (e) {
-      return [];
     }
-    // eslint-disable-next-line no-console
-    console.log(uris);
+  };
+
+  const getJson = async <T>(path: string): Promise<T> => {
+    const res = await fetch(`${endpoint}${path}`);
+    const text = await res.text();
+    if (!res.ok) throw failure('GET', path, res.status, text);
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(
+        `cascade-api ${path} returned non-JSON: ${text.slice(0, 200)}`
+      );
+    }
+  };
+
+  const uploadOne = async (file: GenericFile): Promise<string> => {
+    const body = new FormData();
+    body.append('file', Buffer.from(file.buffer), file.fileName);
+    const data = await postForm<UploadResponse>('/upload', body);
+    if (!data.action_id) {
+      throw new Error(
+        `cascade-api /upload returned no action_id for ${file.fileName}`
+      );
+    }
+    return `${endpoint}/download/${data.action_id}`;
+  };
+
+  const uploadFiles = async (
+    files: GenericFile[],
+    options?: UploaderUploadOptions
+  ): Promise<string[]> => {
+    const uris: string[] = [];
+    for (let i = 0; i < files.length; i += 1) {
+      uris.push(await uploadOne(files[i]));
+      options?.onProgress?.((i + 1) / files.length);
+    }
     return uris;
   };
 
-  const upload2 = async (
-    files: GenericFile[]
-  ): Promise<CascadeUploadedItem[]> => {
-    const body = new FormData();
-
+  const uploadArchive = async (
+    files: GenericFile[],
+    options?: UploaderUploadOptions
+  ): Promise<string[]> => {
+    const seen = new Set<string>();
     files.forEach((file) => {
-      body.append('files', Buffer.from(file.buffer), file.fileName);
+      if (seen.has(file.fileName)) {
+        throw new Error(
+          `archive mode needs unique file names, got "${file.fileName}" ` +
+            'twice — rename the files or use mode: "file"'
+        );
+      }
+      seen.add(file.fileName);
     });
-
-    try {
-      const res = await fetch(
-        `${CASCADE_API_URL}/api/v1/cascade?make_publicly_accessible=true`,
-        {
-          headers: {
-            Api_key: apiKey,
-          },
-          method: 'POST',
-          body,
-        }
-      );
-
-      const data: CascadeUploadResponse = await res.json();
-
-      return data.results;
-    } catch (e) {
-      return [];
+    const body = new FormData();
+    // cascade-api requires non-file fields to precede the first `files` part.
+    body.append('name', 'umi-upload');
+    files.forEach((file) => {
+      // Use `filepath`, not `filename`: form-data strips directories from
+      // `filename`, but cascade-api derives each archive entry's path from the
+      // raw Content-Disposition filename, so the folder path must survive.
+      body.append('files', Buffer.from(file.buffer), {
+        filepath: file.fileName,
+      });
+    });
+    const data = await postForm<UploadResponse>('/upload/folder', body);
+    if (!data.action_id) {
+      throw new Error('cascade-api /upload/folder returned no action_id');
     }
+    options?.onProgress?.(1);
+    return files.map(
+      (file) => `${endpoint}/download/${data.action_id}/${file.fileName}`
+    );
   };
 
-  const uploadJson = async <T>(json: T): Promise<string> => {
-    const file = createGenericFileFromJson(json);
-    const uris = await upload([file]);
-    return uris[0];
+  const upload = async (
+    files: GenericFile[],
+    options?: UploaderUploadOptions
+  ): Promise<string[]> => {
+    if (files.length === 0) return [];
+    return mode === 'archive' && files.length > 1
+      ? uploadArchive(files, options)
+      : uploadFiles(files, options);
   };
+
+  const uploadJson = async <T>(json: T): Promise<string> =>
+    // Metadata is always inscribed as its own action so its URI stays stable
+    // regardless of the mode used for the media files it points at.
+    uploadOne(createGenericFileFromJson(json));
+
+  const estimate = async (sizes: number[]): Promise<CascadeEstimate> => {
+    if (sizes.length === 0) return { totalUlume: BigInt(0), items: [] };
+    const query = sizes.map((size) => Math.max(0, Math.ceil(size))).join(',');
+    const data = await getJson<EstimateResponse>(`/estimate?bytes=${query}`);
+    return {
+      totalUlume: BigInt(data.total_ulume ?? 0),
+      items: (data.items ?? []).map((item) => ({
+        bytes: item.bytes,
+        feeUlume: BigInt(item.fee_ulume),
+      })),
+    };
+  };
+
+  const getUploadPriceUlume = async (files: GenericFile[]): Promise<bigint> => {
+    if (files.length === 0) return BigInt(0);
+    const sizes =
+      mode === 'archive' && files.length > 1
+        ? [files.reduce((sum, file) => sum + file.buffer.byteLength, 0)]
+        : files.map((file) => file.buffer.byteLength);
+    return (await estimate(sizes)).totalUlume;
+  };
+
+  // The caller pays nothing on Solana: the gateway's Lumera key pays the LUME
+  // fee, metered against the API key. The real cost is exposed through
+  // `getUploadPriceUlume` / `estimate` rather than hidden behind a zero.
+  const getUploadPrice = async (): Promise<SolAmount> => lamports(0);
 
   return {
-    getUploadPrice,
     upload,
     uploadJson,
-    upload2,
+    getUploadPrice,
+    estimate,
+    getUploadPriceUlume,
   };
 }

--- a/packages/umi-uploader-cascade/test/CascadeUploader.test.ts
+++ b/packages/umi-uploader-cascade/test/CascadeUploader.test.ts
@@ -41,9 +41,9 @@ test.skip('it can upload one file', async (t) => {
     createGenericFile('some-image', 'some-image.jpg'),
   ]);
 
-  // Then the URI should be a valid IPFS URI.
+  // Then the URI should be a Cascade gateway download URI.
   t.truthy(uri);
-  t.true(uri.startsWith('https://ipfs.io/'));
+  t.true(uri.startsWith('https://api.lumera.help/download/'));
 
   // and it should point to the uploaded asset.
   const [asset] = await context.downloader.download([uri]);


### PR DESCRIPTION
## Summary

`@metaplex-foundation/umi-uploader-cascade` points at `gateway-api.pastel.network`, which is offline post-rebrand, so the package is non-functional. This repoints it to the maintained Lumera Cascade gateway `api.lumera.help` and fixes the known issues.

## Changes

* Repoint default gateway
* Propagate errors instead of swallowing them into `[]`
* Remove a stray `console.log`
* Add an endpoint option and an archive mode (one Cascade action per `upload()` call → one fee, per-file URLs)
* Expose real cost via `estimate` / `getUploadPriceUlume` (`getUploadPrice` stays `0 SOL` the fee is paid in LUME by the gateway, not the Solana caller)

## Breaking

Drops the Pastel-specific `upload2` and `CascadeUploadResponse` / `CascadeUploadedItem` types. Filed as minor since the package was already non-functional and the repo uses linked versioning; happy to bump to major if preferred.

## Testing

Build/lint/test/prettier pass. Verified end-to-end against the live gateway (file round-trip, `uploadJson`, `estimate`, and archive mode with folder paths preserved).

## Note

The hosted gateway requires an operator-issued API key; the uploader keeps `apiKey` required.
