### PR TITLE
feat: add onAccountChange to RpcInterface

### DIFF
--- a/.changeset/rpc-on-account-change.md
+++ b/.changeset/rpc-on-account-change.md
@@ -1,0 +1,6 @@
+---
+"@metaplex-foundation/umi": minor
+"@metaplex-foundation/umi-rpc-web3js": minor
+---
+
+Add `onAccountChange` to `RpcInterface` and implement it in `umi-rpc-web3js`. Account change subscriptions can now be made via `umi.rpc.onAccountChange(publicKey, callback, options)` without reaching into the underlying web3.js connection. The callback receives the updated account as a Umi `RpcAccount` together with the slot context, and the returned function removes the subscription.

--- a/.changeset/rpc-on-account-change.md
+++ b/.changeset/rpc-on-account-change.md
@@ -3,4 +3,4 @@
 "@metaplex-foundation/umi-rpc-web3js": minor
 ---
 
-Add `onAccountChange` to `RpcInterface` and implement it in `umi-rpc-web3js`. Account change subscriptions can now be made via `umi.rpc.onAccountChange(publicKey, callback, options)` without reaching into the underlying web3.js connection. The callback receives the updated account as a Umi `RpcAccount` together with the slot context, and the returned function removes the subscription.
+Add `onAccountChange` to `RpcInterface` and implement it in `umi-rpc-web3js`. Account change subscriptions can now be made via `umi.rpc.onAccountChange(publicKey, callback, options)` without reaching into the underlying web3.js connection. The callback receives the updated account as a Umi `MaybeRpcAccount` together with the slot context, so a closed account arrives with `exists: false`, and the returned function removes the subscription.

--- a/packages/umi-rpc-web3js/package.json
+++ b/packages/umi-rpc-web3js/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@ava/typescript": "^3.0.1",
     "@metaplex-foundation/umi": "workspace:^",
+    "@metaplex-foundation/umi-eddsa-web3js": "workspace:^",
+    "@metaplex-foundation/umi-transaction-factory-web3js": "workspace:^",
     "@solana/web3.js": "^1.72.0",
     "ava": "^5.1.0",
     "jayson": "^3.4.4"

--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -146,7 +146,11 @@ export function createWeb3JsRpc(
   ): RpcUnsubscribe => {
     const id = getConnection().onAccountChange(
       toWeb3JsPublicKey(publicKey),
-      (account, context) => callback(parseAccount(account, publicKey), context),
+      (account, context) =>
+        callback(
+          parseMaybeAccount(account.lamports === 0 ? null : account, publicKey),
+          context
+        ),
       options.commitment
     );
     return () => getConnection().removeAccountChangeListener(id);

--- a/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
+++ b/packages/umi-rpc-web3js/src/createWeb3JsRpc.ts
@@ -16,6 +16,7 @@ import {
   PublicKey,
   resolveClusterFromEndpoint,
   RpcAccount,
+  RpcAccountChangeCallback,
   RpcAccountExistsOptions,
   RpcAirdropOptions,
   RpcCallOptions,
@@ -34,9 +35,11 @@ import {
   RpcGetTransactionOptions,
   RpcGetTransactionResponseOther,
   RpcInterface,
+  RpcOnAccountChangeOptions,
   RpcSendTransactionOptions,
   RpcSimulateTransactionOptions,
   RpcSimulateTransactionResult,
+  RpcUnsubscribe,
   SolAmount,
   Transaction,
   TransactionMetaInnerInstruction,
@@ -134,6 +137,19 @@ export function createWeb3JsRpc(
     return accounts.map(({ pubkey, account }) =>
       parseAccount(account, fromWeb3JsPublicKey(pubkey))
     );
+  };
+
+  const onAccountChange = (
+    publicKey: PublicKey,
+    callback: RpcAccountChangeCallback,
+    options: RpcOnAccountChangeOptions = {}
+  ): RpcUnsubscribe => {
+    const id = getConnection().onAccountChange(
+      toWeb3JsPublicKey(publicKey),
+      (account, context) => callback(parseAccount(account, publicKey), context),
+      options.commitment
+    );
+    return () => getConnection().removeAccountChangeListener(id);
   };
 
   const getBlockTime = async (
@@ -420,6 +436,7 @@ export function createWeb3JsRpc(
     getAccount,
     getAccounts,
     getProgramAccounts,
+    onAccountChange,
     getBlockTime,
     getGenesisHash,
     getBalance,

--- a/packages/umi-rpc-web3js/test/onAccountChange.test.ts
+++ b/packages/umi-rpc-web3js/test/onAccountChange.test.ts
@@ -1,12 +1,22 @@
 import {
+  assertAccountExists,
   createNullContext,
+  MaybeRpcAccount,
   publicKey,
-  RpcAccount,
+  sol,
 } from '@metaplex-foundation/umi';
+import { fromWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters';
+import {
+  Keypair,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js';
 import test from 'ava';
 import { createWeb3JsRpc } from '../src';
 
 const DEVNET_ENDPOINT = 'https://api.devnet.solana.com';
+const LOCALHOST = 'http://127.0.0.1:8899';
 // The clock sysvar is updated every slot, so it is a reliable source of changes.
 const CLOCK_SYSVAR = publicKey('SysvarC1ock11111111111111111111111111111111');
 const SYSVAR_OWNER = publicKey('Sysvar1111111111111111111111111111111111111');
@@ -22,7 +32,7 @@ test('it notifies with the updated account when it changes', async (t) => {
 
   // When we subscribe to an account that changes every slot.
   const { account, context } = await new Promise<{
-    account: RpcAccount;
+    account: MaybeRpcAccount;
     context: { slot: number };
   }>((resolve) => {
     rpc.onAccountChange(CLOCK_SYSVAR, (account, context) => {
@@ -30,12 +40,57 @@ test('it notifies with the updated account when it changes', async (t) => {
     });
   });
 
-  // Then we receive the updated account as a Umi RPC account.
+  // Then we receive the updated account as an existing Umi RPC account.
+  assertAccountExists(account);
   t.is(account.publicKey, CLOCK_SYSVAR);
   t.is(account.owner, SYSVAR_OWNER);
   t.is(account.data.length, 40);
   t.true(account.data instanceof Uint8Array);
   t.true(context.slot > 0);
+});
+
+test('it notifies with a non-existing account once it is closed', async (t) => {
+  // Given a funded payer and a subscription to a fresh account.
+  const rpc = createWeb3JsRpc(createNullContext(), LOCALHOST);
+  const payer = Keypair.generate();
+  const target = Keypair.generate();
+  const targetPublicKey = fromWeb3JsPublicKey(target.publicKey);
+  await rpc.airdrop(fromWeb3JsPublicKey(payer.publicKey), sol(1), {
+    commitment: 'finalized',
+  });
+  const notifications: MaybeRpcAccount[] = [];
+  const unsubscribe = rpc.onAccountChange(
+    targetPublicKey,
+    (account) => {
+      notifications.push(account);
+    },
+    { commitment: 'confirmed' }
+  );
+  const transfer = (from: Keypair, to: Keypair, lamports: number) =>
+    sendAndConfirmTransaction(
+      rpc.connection,
+      new Transaction({ feePayer: payer.publicKey }).add(
+        SystemProgram.transfer({
+          fromPubkey: from.publicKey,
+          toPubkey: to.publicKey,
+          lamports,
+        })
+      ),
+      from === payer ? [payer] : [payer, from],
+      { commitment: 'confirmed' }
+    );
+
+  // When we fund the account and then drain it entirely, which closes it.
+  await transfer(payer, target, 500_000_000);
+  await transfer(target, payer, 500_000_000);
+  await sleep(2000);
+  await unsubscribe();
+
+  // Then we were notified of the funded account followed by the closed one.
+  t.is(notifications.length, 2);
+  t.true(notifications[0].exists);
+  t.false(notifications[1].exists);
+  t.is(notifications[1].publicKey, targetPublicKey);
 });
 
 test('it stops notifying once unsubscribed', async (t) => {

--- a/packages/umi-rpc-web3js/test/onAccountChange.test.ts
+++ b/packages/umi-rpc-web3js/test/onAccountChange.test.ts
@@ -1,0 +1,60 @@
+import {
+  createNullContext,
+  publicKey,
+  RpcAccount,
+} from '@metaplex-foundation/umi';
+import test from 'ava';
+import { createWeb3JsRpc } from '../src';
+
+const DEVNET_ENDPOINT = 'https://api.devnet.solana.com';
+// The clock sysvar is updated every slot, so it is a reliable source of changes.
+const CLOCK_SYSVAR = publicKey('SysvarC1ock11111111111111111111111111111111');
+const SYSVAR_OWNER = publicKey('Sysvar1111111111111111111111111111111111111');
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+test('it notifies with the updated account when it changes', async (t) => {
+  // Given an RPC client.
+  const rpc = createWeb3JsRpc(createNullContext(), DEVNET_ENDPOINT);
+
+  // When we subscribe to an account that changes every slot.
+  const { account, context } = await new Promise<{
+    account: RpcAccount;
+    context: { slot: number };
+  }>((resolve) => {
+    rpc.onAccountChange(CLOCK_SYSVAR, (account, context) => {
+      resolve({ account, context });
+    });
+  });
+
+  // Then we receive the updated account as a Umi RPC account.
+  t.is(account.publicKey, CLOCK_SYSVAR);
+  t.is(account.owner, SYSVAR_OWNER);
+  t.is(account.data.length, 40);
+  t.true(account.data instanceof Uint8Array);
+  t.true(context.slot > 0);
+});
+
+test('it stops notifying once unsubscribed', async (t) => {
+  // Given an RPC client subscribed to an account that changes every slot.
+  const rpc = createWeb3JsRpc(createNullContext(), DEVNET_ENDPOINT);
+  let notifications = 0;
+  let unsubscribe: () => Promise<void> = async () => {};
+  await new Promise<void>((resolve) => {
+    unsubscribe = rpc.onAccountChange(CLOCK_SYSVAR, () => {
+      notifications += 1;
+      resolve();
+    });
+  });
+
+  // When we unsubscribe.
+  await unsubscribe();
+  const countAfterUnsubscribe = notifications;
+
+  // Then no further notifications arrive.
+  await sleep(2000);
+  t.is(notifications, countAfterUnsubscribe);
+});

--- a/packages/umi-rpc-web3js/test/onAccountChange.test.ts
+++ b/packages/umi-rpc-web3js/test/onAccountChange.test.ts
@@ -1,41 +1,61 @@
 import {
   assertAccountExists,
-  createNullContext,
+  createBaseUmi,
+  generatedSignerIdentity,
+  generateSigner,
   MaybeRpcAccount,
+  PublicKey,
   publicKey,
+  RpcUnsubscribe,
+  Signer,
   sol,
+  transactionBuilder,
 } from '@metaplex-foundation/umi';
-import { fromWeb3JsPublicKey } from '@metaplex-foundation/umi-web3js-adapters';
+import { web3JsEddsa } from '@metaplex-foundation/umi-eddsa-web3js';
+import { web3JsTransactionFactory } from '@metaplex-foundation/umi-transaction-factory-web3js';
 import {
-  Keypair,
-  sendAndConfirmTransaction,
-  SystemProgram,
-  Transaction,
-} from '@solana/web3.js';
+  fromWeb3JsInstruction,
+  toWeb3JsPublicKey,
+} from '@metaplex-foundation/umi-web3js-adapters';
+import { SystemProgram } from '@solana/web3.js';
 import test from 'ava';
-import { createWeb3JsRpc } from '../src';
+import { web3JsRpc } from '../src';
 
-const DEVNET_ENDPOINT = 'https://api.devnet.solana.com';
 const LOCALHOST = 'http://127.0.0.1:8899';
 // The clock sysvar is updated every slot, so it is a reliable source of changes.
 const CLOCK_SYSVAR = publicKey('SysvarC1ock11111111111111111111111111111111');
 const SYSVAR_OWNER = publicKey('Sysvar1111111111111111111111111111111111111');
 
-const sleep = (ms: number) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
+const createUmi = () =>
+  createBaseUmi()
+    .use(web3JsEddsa())
+    .use(web3JsTransactionFactory())
+    .use(web3JsRpc(LOCALHOST, 'confirmed'))
+    .use(generatedSignerIdentity());
+
+const transferSol = (from: Signer, to: PublicKey, lamports: number) =>
+  transactionBuilder().add({
+    instruction: fromWeb3JsInstruction(
+      SystemProgram.transfer({
+        fromPubkey: toWeb3JsPublicKey(from.publicKey),
+        toPubkey: toWeb3JsPublicKey(to),
+        lamports,
+      })
+    ),
+    signers: [from],
+    bytesCreatedOnChain: 0,
   });
 
 test('it notifies with the updated account when it changes', async (t) => {
-  // Given an RPC client.
-  const rpc = createWeb3JsRpc(createNullContext(), DEVNET_ENDPOINT);
+  // Given a Umi instance.
+  const umi = createUmi();
 
   // When we subscribe to an account that changes every slot.
   const { account, context } = await new Promise<{
     account: MaybeRpcAccount;
     context: { slot: number };
   }>((resolve) => {
-    rpc.onAccountChange(CLOCK_SYSVAR, (account, context) => {
+    umi.rpc.onAccountChange(CLOCK_SYSVAR, (account, context) => {
       resolve({ account, context });
     });
   });
@@ -50,56 +70,41 @@ test('it notifies with the updated account when it changes', async (t) => {
 });
 
 test('it notifies with a non-existing account once it is closed', async (t) => {
-  // Given a funded payer and a subscription to a fresh account.
-  const rpc = createWeb3JsRpc(createNullContext(), LOCALHOST);
-  const payer = Keypair.generate();
-  const target = Keypair.generate();
-  const targetPublicKey = fromWeb3JsPublicKey(target.publicKey);
-  await rpc.airdrop(fromWeb3JsPublicKey(payer.publicKey), sol(1), {
-    commitment: 'finalized',
-  });
+  // Given a funded identity and a subscription to a fresh account.
+  const umi = createUmi();
+  await umi.rpc.airdrop(umi.identity.publicKey, sol(1));
+  const target = generateSigner(umi);
   const notifications: MaybeRpcAccount[] = [];
-  const unsubscribe = rpc.onAccountChange(
-    targetPublicKey,
-    (account) => {
-      notifications.push(account);
-    },
-    { commitment: 'confirmed' }
-  );
-  const transfer = (from: Keypair, to: Keypair, lamports: number) =>
-    sendAndConfirmTransaction(
-      rpc.connection,
-      new Transaction({ feePayer: payer.publicKey }).add(
-        SystemProgram.transfer({
-          fromPubkey: from.publicKey,
-          toPubkey: to.publicKey,
-          lamports,
-        })
-      ),
-      from === payer ? [payer] : [payer, from],
-      { commitment: 'confirmed' }
-    );
+  const unsubscribe = umi.rpc.onAccountChange(target.publicKey, (account) => {
+    notifications.push(account);
+  });
 
   // When we fund the account and then drain it entirely, which closes it.
-  await transfer(payer, target, 500_000_000);
-  await transfer(target, payer, 500_000_000);
-  await sleep(2000);
+  await transferSol(umi.identity, target.publicKey, 500000000).sendAndConfirm(
+    umi
+  );
+  await transferSol(target, umi.identity.publicKey, 500000000).sendAndConfirm(
+    umi
+  );
+  await new Promise((resolve) => {
+    setTimeout(resolve, 2000);
+  });
   await unsubscribe();
 
   // Then we were notified of the funded account followed by the closed one.
   t.is(notifications.length, 2);
   t.true(notifications[0].exists);
   t.false(notifications[1].exists);
-  t.is(notifications[1].publicKey, targetPublicKey);
+  t.is(notifications[1].publicKey, target.publicKey);
 });
 
 test('it stops notifying once unsubscribed', async (t) => {
-  // Given an RPC client subscribed to an account that changes every slot.
-  const rpc = createWeb3JsRpc(createNullContext(), DEVNET_ENDPOINT);
+  // Given a Umi instance subscribed to an account that changes every slot.
+  const umi = createUmi();
   let notifications = 0;
-  let unsubscribe: () => Promise<void> = async () => {};
+  let unsubscribe: RpcUnsubscribe = async () => {};
   await new Promise<void>((resolve) => {
-    unsubscribe = rpc.onAccountChange(CLOCK_SYSVAR, () => {
+    unsubscribe = umi.rpc.onAccountChange(CLOCK_SYSVAR, () => {
       notifications += 1;
       resolve();
     });
@@ -110,6 +115,8 @@ test('it stops notifying once unsubscribed', async (t) => {
   const countAfterUnsubscribe = notifications;
 
   // Then no further notifications arrive.
-  await sleep(2000);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 2000);
+  });
   t.is(notifications, countAfterUnsubscribe);
 });

--- a/packages/umi/src/RpcInterface.ts
+++ b/packages/umi/src/RpcInterface.ts
@@ -71,6 +71,7 @@ export interface RpcInterface {
    *
    * @param publicKey The public key of the account to watch.
    * @param callback The function to call with the updated account each time it changes.
+   * Once the account is closed, it receives an account that does not exist.
    * @param options The options to use when subscribing to the account.
    * @returns A function that removes the subscription.
    */
@@ -341,10 +342,11 @@ export type RpcOnAccountChangeOptions = {
 
 /**
  * The function called each time a watched account changes.
+ * Once the watched account is closed, it receives an account that does not exist.
  * @category Rpc
  */
 export type RpcAccountChangeCallback = (
-  account: RpcAccount,
+  account: MaybeRpcAccount,
   context: { slot: number }
 ) => void;
 

--- a/packages/umi/src/RpcInterface.ts
+++ b/packages/umi/src/RpcInterface.ts
@@ -67,6 +67,20 @@ export interface RpcInterface {
   ): Promise<RpcAccount[]>;
 
   /**
+   * Subscribe to changes of the account at the given address.
+   *
+   * @param publicKey The public key of the account to watch.
+   * @param callback The function to call with the updated account each time it changes.
+   * @param options The options to use when subscribing to the account.
+   * @returns A function that removes the subscription.
+   */
+  onAccountChange(
+    publicKey: PublicKey,
+    callback: RpcAccountChangeCallback,
+    options?: RpcOnAccountChangeOptions
+  ): RpcUnsubscribe;
+
+  /**
    * Fetch the estimated production time of a block.
    *
    * @param slot The slot to get the estimated production time for.
@@ -317,6 +331,30 @@ export type RpcGetProgramAccountsOptions = RpcBaseOptions & {
 };
 
 /**
+ * The options to use when subscribing to account changes.
+ * @category Rpc
+ */
+export type RpcOnAccountChangeOptions = {
+  /** The commitment level to use when watching the account. */
+  commitment?: Commitment;
+};
+
+/**
+ * The function called each time a watched account changes.
+ * @category Rpc
+ */
+export type RpcAccountChangeCallback = (
+  account: RpcAccount,
+  context: { slot: number }
+) => void;
+
+/**
+ * A function that removes an RPC subscription.
+ * @category Rpc
+ */
+export type RpcUnsubscribe = () => Promise<void>;
+
+/**
  * The options to use when fetching a block.
  * @category Rpc
  */
@@ -536,6 +574,7 @@ export function createNullRpc(): RpcInterface {
     getAccount: errorHandler,
     getAccounts: errorHandler,
     getProgramAccounts: errorHandler,
+    onAccountChange: errorHandler,
     getBlockTime: errorHandler,
     getBalance: errorHandler,
     getRent: errorHandler,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,12 @@ importers:
       '@metaplex-foundation/umi':
         specifier: workspace:^
         version: link:../umi
+      '@metaplex-foundation/umi-eddsa-web3js':
+        specifier: workspace:^
+        version: link:../umi-eddsa-web3js
+      '@metaplex-foundation/umi-transaction-factory-web3js':
+        specifier: workspace:^
+        version: link:../umi-transaction-factory-web3js
       '@solana/web3.js':
         specifier: ^1.72.0
         version: 1.72.0


### PR DESCRIPTION
Expose account change subscriptions on umi.rpc so callers no longer need to reach into the underlying web3.js connection. The callback receives the updated account as a Umi RpcAccount with the slot context, and the returned function removes the subscription.


Claude-Session: https://claude.ai/code/session_01DCPJB9c2pYEqrPaV96MGNN